### PR TITLE
P1 make highlights involving c d e consistently work

### DIFF
--- a/contents/b1sec2prop1/js/decs-conf.js
+++ b/contents/b1sec2prop1/js/decs-conf.js
@@ -48,7 +48,7 @@
         Object.assign( decor, firstSteps_conf );
 
         //----------------------------------------------------
-        // //\\ proof final points
+        // //\\ proof points initial settings
         //----------------------------------------------------
         var CDEF_conf = {
             C   : { decStart : 6, },
@@ -56,14 +56,14 @@
             E   : { decStart : 14, },
             F   : { decStart : 18 },
         };
-        ///makes proof final points to disappear after a while
+        ///makes proof points disappear after a while
         eachprop( CDEF_conf, (fs, kName) => {
             fs.decEnd = sconf.numberOfManyBases*4 *
                         sconf.FIRST_POINT_LABELS_DISPLAY_LIMIT;
         });
         Object.assign( decor, CDEF_conf );
         //----------------------------------------------------
-        // \\// proof final points
+        // \\// proof points initial settings
         //----------------------------------------------------
 
 
@@ -463,12 +463,6 @@
         //---------------------------------------------------
         // \\// syncs decor and rg
         //---------------------------------------------------
-        ssD.logicalSteps = [
-            rg.C, rg.V, rg.c, rg.Cc, rg.Bc, rg.BC, rg.SC, rg.Sc, rg.SBc,
-            rg.D, rg.d, rg.Dd, rg.Cd, rg.CD, rg.SD, rg.Sd, rg.SCd, rg.SABCD, 
-            rg.E, rg.e, rg.Ee, rg.De, rg.DE, rg.SE, rg.Se, rg.SDe,
-            rg.F, rg.f, rg.Ff, rg.Ef, rg.EF, rg.SF, rg.Sf, rg.SEf, rg.SABCDEF,
-        ];
     }
     //----------------------------------------
     // \\// declares decorations

--- a/contents/b1sec2prop1/js/media-model.js
+++ b/contents/b1sec2prop1/js/media-model.js
@@ -99,6 +99,18 @@
             rg.SEf.decStart = last;
             rg.SABCDEF.decStart = last;
         }
+
+        //Update decEnd for the following decorations, to ensure they are hidden once the time slider is advanced beyond point F.
+        [
+            rg.c, rg.Cc, rg.Bc, rg.Sc, rg.SBc,
+            rg.d, rg.Dd, rg.Cd, rg.SD, rg.Sd, rg.SCd, rg.SABCD, 
+            rg.e, rg.Ee, rg.De, rg.SE, rg.Se, rg.SDe,
+            rg.f, rg.Ff, rg.Ef, rg.SF, rg.Sf, rg.SEf, rg.SABCDEF,
+        ].forEach( pn => {
+            pn.decEnd = rg.f.decStart+3;
+        });
+
+
         //-------------------------------------------------------
         // //\\ fixes logical step to 7 for corollary of P2
         //-------------------------------------------------------
@@ -106,9 +118,6 @@
         lemmaP2coroll.forEach( pn => {
             rg[pn].decStart = CStart;
             rg[pn].decEnd = CStart+3;
-         });
-        ssD.logicalSteps.forEach( pn => {
-            pn.decEnd = rg.f.decStart+3;
          });
         if(
             amode.subessay === 'cor-1' ||


### PR DESCRIPTION
-Moved and modified code that hides decorations once the time slider is advanced beyond point F.
-C, D, E, F are now kept visible