### PR TITLE
Rename "theorion" to "textSection" (and related terms) (#16)

### DIFF
--- a/contents/README-HOW-TO-SCRIPT.txt
+++ b/contents/README-HOW-TO-SCRIPT.txt
@@ -3,7 +3,7 @@ Handy help
 ==========
 
 example: makes self-reference in content-script
-<a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#scholium">
+<a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#scholium">
 
 
 
@@ -38,13 +38,13 @@ Text inside { } is sets essay options which must be written in JSON format.
 Part {...} is optional.
 
 Pair like corollary|english above is an index of essay comprised of two categories
-<theorion>|<aspect>
+<textSection>|<aspect>
 which in given case is corollary|english.
 
-theorions currently are claim, proof, corollary, ... but can be any words,
+textSections currently are claim, proof, corollary, ... but can be any words,
 aspects currently are claim, proof, corollary, ... but can be any words.
 
-theorions comprise horizontal menu in reader's work space in browser,
+textSections comprise horizontal menu in reader's work space in browser,
 aspects go to vertical menu.
 
 
@@ -141,7 +141,7 @@ this contains another JSON, not a JSON for active fragments
     ------
         *::*claim|xixcentury
         {
-          "theorionCaption" : "This is problem 2",
+          "textSectionCaption" : "This is problem 2",
           "dataLegend":"0",
           "mediaBgImage" : null,
 
@@ -156,7 +156,7 @@ this contains another JSON, not a JSON for active fragments
 
     description of above JSON
     ------------------------- 
-        "theorionCaption" : "This is problem 2",- makes GUI caption (usually for horizontal menu),
+        "textSectionCaption" : "This is problem 2",- makes GUI caption (usually for horizontal menu),
         "default" : "1",                        - makes this essay default at site-landing,
         "mediaBgImage" : null,                  - loads empty image,
         "mediaBgImage" : 'my-bg-image.png',     - loads contents/.../img/my-bg-image.png,

--- a/contents/addd-conics/js/amode8captures.js
+++ b/contents/addd-conics/js/amode8captures.js
@@ -49,7 +49,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         var media_scale = toreg( 'media_scale' )();
         rg.media_scale.value = 1;
         ssF.scaleValue2app( rg.media_scale.value, stdMod );

--- a/contents/addd-conics/js/main-legend.js
+++ b/contents/addd-conics/js/main-legend.js
@@ -27,11 +27,11 @@
     {
         return;
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -88,11 +88,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -161,7 +161,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/addd-fw/texts.content.txt
+++ b/contents/addd-fw/texts.content.txt
@@ -35,13 +35,13 @@ Addendum, in Programming Guide, may also include anything interesting like progr
 ⦁  References to original text lemma are in parenthesises. For example,
 <br><br>
 
-<a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#theorem-2">"Lemma (Theorem II)"</a>
+<a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#theorem-2">"Lemma (Theorem II)"</a>
 <br><br>
 
 refers to
 <br><br>
 
-<a target="_blank" href="?conf=sappId=b1sec2prop2,theorionId=proof,aspectId=english">"Book 1. Section II. Proposition II. Theorem II".</a>
+<a target="_blank" href="?conf=sappId=b1sec2prop2,textSectionId=proof,aspectId=english">"Book 1. Section II. Proposition II. Theorem II".</a>
 <br><br>
 
 <div book-reference-id="kvk"></div>

--- a/contents/addd-kepler-task/texts.content.txt
+++ b/contents/addd-kepler-task/texts.content.txt
@@ -49,7 +49,7 @@ Full force acting on the body will be
 Now instead of arbitrary speed, take speed v which makes sector speed constant.
 
     <div style="text-align:center;">
-        1/2[𝗿𝘃]𝗸 = 1/2 vr[<a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=calculus-xx">𝗲𝘂</a>]<sub>𝗸</sub> = M/2 = const,
+        1/2[𝗿𝘃]𝗸 = 1/2 vr[<a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=calculus-xx">𝗲𝘂</a>]<sub>𝗸</sub> = M/2 = const,
 
         &nbsp;&nbsp;&nbsp;&nbsp;(k)<br>
         M is called orbital momentum.<br>
@@ -369,7 +369,7 @@ forces in respect to each other:
 <br>
 
 
-From <a target="_blank" href="?conf=sappId=addd-conics,theorionId=proof,aspectId=addendum,subessayId=interval">
+From <a target="_blank" href="?conf=sappId=addd-conics,textSectionId=proof,aspectId=addendum,subessayId=interval">
 "Interval between conjugate parallels",  (𝛺)</a>:
         𝘨 / ρ<sub>φ</sub> = 𝛺<sub>φ</sub> / 𝛺<sub>𝛙</sub>.
 <br>

--- a/contents/addd-prel-curve/js/amode8captures.js
+++ b/contents/addd-prel-curve/js/amode8captures.js
@@ -34,7 +34,7 @@
 
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
 
         /*
         //fails:
@@ -61,7 +61,7 @@
         /*
         if( fconf.sappId === "b1sec1lemma6" ) {
             captured = "reset-to-origin";
-            if( theorion === 'claim' ) {
+            if( textSection === 'claim' ) {
                  captured = 'L-equal-d';
             }
         }

--- a/contents/addd-prel-curve/texts.content.txt
+++ b/contents/addd-prel-curve/texts.content.txt
@@ -522,7 +522,7 @@ Then (i),(ii),(iii) will hold too.
 <br><br>
 <b>r</b> is measurable if there exist set of
 
-<a target="_blank" href="?conf=sappId=addd-prel,theorionId=proof,aspectId=algebraic-extension,subessayId=real-magnitudes">
+<a target="_blank" href="?conf=sappId=addd-prel,textSectionId=proof,aspectId=algebraic-extension,subessayId=real-magnitudes">
 real magnitudes L
 </a>
 

--- a/contents/addd-prel-curveXX/js/study-model.js
+++ b/contents/addd-prel-curveXX/js/study-model.js
@@ -45,9 +45,9 @@
     function model_upcreate()
     {
         //this patch amends this css
-        //.bsl-approot.theorion--corollary.aspect--english .bsl--svgscene.s ubmodel-common
+        //.bsl-approot.textSection--corollary.aspect--english .bsl--svgscene.s ubmodel-common
 
-        //img competes with: .bsl-approot.theorion--scholium.aspect--english .bg0,
+        //img competes with: .bsl-approot.textSection--scholium.aspect--english .bg0,
         //todm: inconsistent: .main-legend.proof should not need this CSS, it
         //      is designed to remove itself by class ".proof",
         var wwCss =

--- a/contents/addd-prel/texts.content.txt
+++ b/contents/addd-prel/texts.content.txt
@@ -23,11 +23,11 @@
 
 Here we follow the articles of
 
-<a target="_blank" href="?conf=sappId=addd-prel,theorionId=proof,aspectId=algebraic-extension,subessayId=references#ctxt-salomon-ofman-euclid-theory-of-ratio">Salomon Ofman</a>
+<a target="_blank" href="?conf=sappId=addd-prel,textSectionId=proof,aspectId=algebraic-extension,subessayId=references#ctxt-salomon-ofman-euclid-theory-of-ratio">Salomon Ofman</a>
 
 and
 
-<a target="_blank" href="?conf=sappId=addd-prel,theorionId=proof,aspectId=algebraic-extension,subessayId=references#ctxt-howard-stein-eudoxos-and-dedekind">Howard Stein</a>
+<a target="_blank" href="?conf=sappId=addd-prel,textSectionId=proof,aspectId=algebraic-extension,subessayId=references#ctxt-howard-stein-eudoxos-and-dedekind">Howard Stein</a>
 
 <br><br><br>
 

--- a/contents/b1sec1lemma10/js/amode8captures.js
+++ b/contents/b1sec1lemma10/js/amode8captures.js
@@ -25,7 +25,7 @@
 
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
 
         //hides all proof material, proof is already done in lemma 9
         [
@@ -59,7 +59,7 @@
         rg.Ag.pcolor = sDomF.getFixedColor( 'given' )
 
         if(
-            theorion === 'proof'
+            textSection === 'proof'
         ) {
             rg.tiltRatio = { value : 1.3 };
             [

--- a/contents/b1sec1lemma11/js/main-legend.js
+++ b/contents/b1sec1lemma11/js/main-legend.js
@@ -25,11 +25,11 @@
 
     function create_digital_legend()
     {
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -55,9 +55,9 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             stdMod_given : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             noTableTitle : true,
@@ -88,7 +88,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec1lemma11/txt/addendum.txt
+++ b/contents/b1sec1lemma11/txt/addendum.txt
@@ -280,7 +280,7 @@
             }
         ],
         [
-            " theorion === 'claim' ",
+            " textSection === 'claim' ",
             {
                 "rg" :
                 {
@@ -307,7 +307,7 @@
             }
         ],
         [
-            "( theorion === 'proof'|| theorion === 'corollary' )",
+            "( textSection === 'proof'|| textSection === 'corollary' )",
             {
                 "rg" :
                 {
@@ -315,7 +315,7 @@
             }
         ],
         [
-            "aspect === 'model' && theorion === 'proof'",
+            "aspect === 'model' && textSection === 'proof'",
             {
                 "rg" :
                 {
@@ -334,7 +334,7 @@
             }
         ],
         [
-            "aspect === 'model' && theorion === 'proof' && subessay === 'second-derivative'",
+            "aspect === 'model' && textSection === 'proof' && subessay === 'second-derivative'",
             {
                 "rg" :
                 {
@@ -346,7 +346,7 @@
             }
         ],
         [
-            "theorion === 'corollary' || aspect === 'model'",
+            "textSection === 'corollary' || aspect === 'model'",
             {
                 "rg" :
                 {

--- a/contents/b1sec1lemma4/js/amode8captures.js
+++ b/contents/b1sec1lemma4/js/amode8captures.js
@@ -46,7 +46,7 @@
 
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         //----------------------------------
         // //\\ common values
         //----------------------------------
@@ -61,7 +61,7 @@
         //----------------------------------
 
 
-        if( theorion === 'proof' ){
+        if( textSection === 'proof' ){
 
             //todo ... why was it 0.7? and not 1?
             //         this made problems with bars number > DONT_PAINT_BARS_MORE_THAN

--- a/contents/b1sec1lemma4/js/main-legend.js
+++ b/contents/b1sec1lemma4/js/main-legend.js
@@ -26,11 +26,11 @@
     function create_digital_legend()
     {
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -87,11 +87,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -160,7 +160,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec1lemma6/js/amode8captures.js
+++ b/contents/b1sec1lemma6/js/amode8captures.js
@@ -181,7 +181,7 @@
 
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         //------------------------------------------------
         // //\\ returns diagram back at every menu click
         //      todm: this is a patch: do streamline
@@ -234,7 +234,7 @@
         if( fconf.sappId === "b1sec1lemma6" ) {
             rg.L.doPaintPname = false;
             captured = "reset-to-origin";
-            if( theorion === 'claim' ) {
+            if( textSection === 'claim' ) {
                  captured = 'L-equal-d';
             }
             //ns.paste( rg.curveStart.pos, [ -0.2, 0 ] );
@@ -248,7 +248,7 @@
                 'C',
             ].forEach( gname => { rg[ gname ].undisplay = false; });
             if(
-                theorion === 'proof' || theorion === 'claim' 
+                textSection === 'proof' || textSection === 'claim' 
             ) {
                 sDomF.detected_user_interaction_effect( 'doUndetected' );
                 [
@@ -260,7 +260,7 @@
 
             //below we do add points and lines which are absent in N. proof
             if(
-                theorion === 'proof'
+                textSection === 'proof'
             ) {
                 rg.L.hideCaption = true;
                 [
@@ -279,7 +279,7 @@
             }
 
             if(
-                ( theorion === 'proof' || theorion === 'claim' ) && aspect === 'model'
+                ( textSection === 'proof' || textSection === 'claim' ) && aspect === 'model'
             ) {
                 [
                     'arc-Ab',
@@ -294,7 +294,7 @@
 
                 ///this still needs user action to replace Book's letters with
                 ///pop up app. letters
-                if( theorion === 'proof' ) {
+                if( textSection === 'proof' ) {
                     rg.curveRotationAngle.angle = ANGLE_AUTH;
                     sDomF.detected_user_interaction_effect( !'doUndetected' );
                     rg.L.undisplay = false;
@@ -490,7 +490,7 @@
             }
 
             
-            if( theorion === 'corollary' ) {
+            if( textSection === 'corollary' ) {
                 [
                     'curve-AB',
                     'left-curve-AB',
@@ -521,7 +521,7 @@
                     'curve-AB',
                 ].forEach( gname => { rg[ gname ].undisplay = false; });
 
-                if( theorion === 'proof' ) {
+                if( textSection === 'proof' ) {
                     sDomF.detected_user_interaction_effect( 'doUndetected' );
                     [
                         'c',
@@ -589,7 +589,7 @@
                 'fi',
             ].forEach( gname => { rg[ gname ].undisplay = false; });
 
-            if( theorion === 'claim' ) {
+            if( textSection === 'claim' ) {
                 [
                     'c',
                     'rd',
@@ -601,7 +601,7 @@
                     'imageOfR,b',
                     'imageOfR,imageOfD',
                 ].forEach( gname => { rg[ gname ].undisplay = true; });
-            } else if( theorion === 'proof' ) {
+            } else if( textSection === 'proof' ) {
                 [
                     'c',
                     //'d',
@@ -622,7 +622,7 @@
                     'arc-Ab',
                 ].forEach( gname => { rg[ gname ].undisplay = false; });
             }
-            if( theorion === 'claim' || theorion === 'corollary' ) {
+            if( textSection === 'claim' || textSection === 'corollary' ) {
                 if( userOptions.showingBonusFeatures() ) {
                     rg.B.hideD8Dpoint   = false;
                     rg.R.hideD8Dpoint   = false;

--- a/contents/b1sec1lemma6/js/init-model-parameters.js
+++ b/contents/b1sec1lemma6/js/init-model-parameters.js
@@ -152,7 +152,7 @@
                 
                 if( fconf.sappId === "b1sec1lemma6" &&
                     //core essays:
-                    ( !(amode.aspect === 'model') && amode.theorion === 'proof' ) && 
+                    ( !(amode.aspect === 'model') && amode.textSection === 'proof' ) && 
                     (angleBAM < 0 || cpos[1] > -0.01)
                 ){
                     adjust_new_unrotatedParameterX_asNeccesary();

--- a/contents/b1sec1lemma6/js/main-legend.js
+++ b/contents/b1sec1lemma6/js/main-legend.js
@@ -175,16 +175,16 @@
     function create_digital_legend()
     {
         var lsX = fconf.sappId === "b1sec1lemma6" ? legendScript : legendScript7;
-        eachprop( lsX, (theorionLegend, theoName) => {
-            creAUX( theoName, theorionLegend );
+        eachprop( lsX, (textSectionLegend, theoName) => {
+            creAUX( theoName, textSectionLegend );
         });
     }
 
-    function creAUX( theoName, theorionLegend )
+    function creAUX( theoName, textSectionLegend )
     {
         ///spawns configuration
         ///returns array-of-lines, line = array-of-clusters, cluster=array-of-tokens,
-        var legendScriptParsed = theorionLegend.map( (line,lix) => {
+        var legendScriptParsed = textSectionLegend.map( (line,lix) => {
             var lparsed = line.split(/\s+/);
             return lparsed.map( clusterToken => {
                 return clusterToken.split(',');
@@ -193,11 +193,11 @@
         var rowsCount       = legendScriptParsed.length;
         var clustersCount   = legendScriptParsed[0].length;
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : '', //'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion        : theoName,
+            textSection        : theoName,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -233,7 +233,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec1lemma6/js/media-upcreate.js
+++ b/contents/b1sec1lemma6/js/media-upcreate.js
@@ -33,8 +33,8 @@
         //=================================================
         var rgMainLegend = haz( rg, 'main-legend' );
         if( rgMainLegend ) {
-            var rgTeoTab = rgMainLegend[ amode.theorion ];
-            if( amode.theorion === 'corollary' && amode.aspect === 'model' ) {
+            var rgTeoTab = rgMainLegend[ amode.textSection ];
+            if( amode.textSection === 'corollary' && amode.aspect === 'model' ) {
                 $$.$( rgTeoTab.tableDom ).addClass( 'hidden' );
             } else {
                 $$.$( rgTeoTab.tableDom ).removeClass( 'hidden' );

--- a/contents/b1sec1lemma6/js/model-functions.js
+++ b/contents/b1sec1lemma6/js/model-functions.js
@@ -51,7 +51,7 @@
                 fun : function(x) {
                         //patch:
                         if( fconf.sappId === "b1sec1lemma6" &&
-                            amode.aspect === 'model' && amode.theorion === 'proof'
+                            amode.aspect === 'model' && amode.textSection === 'proof'
                         ) {
                             var anRack = rg.curveRotationAngle;
                         } else {

--- a/contents/b1sec1lemma6/txt/addendum-comment.txt
+++ b/contents/b1sec1lemma6/txt/addendum-comment.txt
@@ -11,22 +11,22 @@ A supposition of lemma 6 is that curve has continuous curvature. This can mean t
 <br><br>
 1. Curve has no "corner". In other words, 
 
-<a target="_blank" href="?conf=sappId=addd-prel-curve,theorionId=proof,aspectId=curve,subessayId=euclid-framework-curves#onc-side-euclidean-tangent">
+<a target="_blank" href="?conf=sappId=addd-prel-curve,textSectionId=proof,aspectId=curve,subessayId=euclid-framework-curves#onc-side-euclidean-tangent">
 left and right Euclidean tangents are on the same line.
 </a>
  
 However, lemma 6 is
 
-<a target="_blank" href="?conf=sappId=addd-prel-curve,theorionId=proof,aspectId=curve,subessayId=continuous-if-curve#cif-breaks-l6">incorrect in this case.</a>
+<a target="_blank" href="?conf=sappId=addd-prel-curve,textSectionId=proof,aspectId=curve,subessayId=continuous-if-curve#cif-breaks-l6">incorrect in this case.</a>
 
 Even when curve is continous.
 <br><br>
 
 2. Second meaning can be that curve has continuous
 
-<a target="_blank" href="?conf=sappId=addd-prel-curve,theorionId=proof,aspectId=curve,subessayId=circle-based-curvature#circlescribed-curvature-anchor">CircleScribed curvature</a>.
+<a target="_blank" href="?conf=sappId=addd-prel-curve,textSectionId=proof,aspectId=curve,subessayId=circle-based-curvature#circlescribed-curvature-anchor">CircleScribed curvature</a>.
 
-<a target="_blank" href="?conf=sappId=addd-prel-curve,theorionId=proof,aspectId=curve,subessayId=infinite-frequency-circle-based-curvature#if-circlescribed-curve">
+<a target="_blank" href="?conf=sappId=addd-prel-curve,textSectionId=proof,aspectId=curve,subessayId=infinite-frequency-circle-based-curvature#if-circlescribed-curve">
 In this case Lemma 6 is also incorrect.
 </a>
 
@@ -136,12 +136,12 @@ then
 <b>I. Newtons logic in Lemma 11,</b>
 <br>
 strongly suggests that by word "curvatue", Newton means
-<a target="_blank" href="?conf=sappId=addd-prel-curve,theorionId=proof,aspectId=curve,subessayId=circle-based-curvature#circlescribed-curvature-anchor">
+<a target="_blank" href="?conf=sappId=addd-prel-curve,textSectionId=proof,aspectId=curve,subessayId=circle-based-curvature#circlescribed-curvature-anchor">
 "CirlescribedCurvature"
 </a>
 <br><br>
 
-<a target="_blank" href="?conf=sappId=b1sec1lemma11,theorionId=proof,aspectId=english">
+<a target="_blank" href="?conf=sappId=b1sec1lemma11,textSectionId=proof,aspectId=english">
 Drag point B to A and see that point G has limit J.
 </a>
 
@@ -153,7 +153,7 @@ R → R<sub>c</sub> or 2R=D → D<sub>c</sub>=J.
 (CircleSribed curvature is not the curvature χ in CalculusXX where it is |d²<b>r</b>/ds²|.
 Yes, when χ exists, then CircleSribed curvature does exist too and = χ = 1/R<sub>c</sub>, but not other way around:
 
-<a target="_blank" href="?conf=sappId=addd-prel-curve,theorionId=proof,aspectId=curve,subessayId=infinite-frequency-circle-based-curvature#if-circlescribed-curve">
+<a target="_blank" href="?conf=sappId=addd-prel-curve,textSectionId=proof,aspectId=curve,subessayId=infinite-frequency-circle-based-curvature#if-circlescribed-curve">
 for this curve
 </a>
 CircleSribed curvature does exist, but χ does not because
@@ -171,13 +171,13 @@ even the first derivative d<b>r</b>/dt does not exist.
 a) curve is differentiable
 <br>
 <a target="_blank" href="?conf=sappId=b1sec1lemma6,
-theorionId=proof,aspectId=model#differential-version">
+textSectionId=proof,aspectId=model#differential-version">
 b) differential tangents exist
 </a>
 <br>
 
 <a target="_blank" href="?conf=sappId=b1sec1lemma6,
-theorionId=proof,aspectId=model#differential-version">
+textSectionId=proof,aspectId=model#differential-version">
 c) chord angle has a limit
 </a>
 <br><br><br>
@@ -185,7 +185,7 @@ c) chord angle has a limit
 
 
 <b>Variant 2.<a target="_blank" href="?conf=sappId=b1sec1lemma6,
-theorionId=proof,aspectId=model#pure-convex-version">
+textSectionId=proof,aspectId=model#pure-convex-version">
 Lemma 6. Pure convex version.
 </a></b> Apparently chosen in Dana Densmore book.
 However, this does not need any premise of "continuity" and "curvature".
@@ -304,7 +304,7 @@ then
 (i') for ¦curve-AB¦ACB¦¦ which lies on one side of ray ¦AL¦¦ in some of neighborhood of point ¦A¦¦ except point ¦A¦¦, <br><br>
 ¦AL¦¦ is
 
-<a target="_blank" href="?conf=sappId=addd-prel-curve,theorionId=proof,aspectId=curve,subessayId=euclid-framework-curves#onc-side-euclidean-tangent">
+<a target="_blank" href="?conf=sappId=addd-prel-curve,textSectionId=proof,aspectId=curve,subessayId=euclid-framework-curves#onc-side-euclidean-tangent">
 one-side Euclidean tangent,
 </a>
 

--- a/contents/b1sec1lemma8/txt/addendum.txt
+++ b/contents/b1sec1lemma8/txt/addendum.txt
@@ -20,7 +20,7 @@
 <b>In <><>CXX:</b><br><br>
 
 If curve
-<a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=frenet-serret">
+<a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=frenet-serret">
 is continuously differentiable,
 </a>
 
@@ -70,7 +70,7 @@ which is a finite form of above differential equalities (*).
 
 
 If curve
-<a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=frenet-serret">
+<a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=frenet-serret">
 is continuously differentiable,
 </a>
 

--- a/contents/b1sec1lemma9/js/amode8captures.js
+++ b/contents/b1sec1lemma9/js/amode8captures.js
@@ -25,9 +25,9 @@
 
     function amode2rgstate( captured )
     {
-        var { theorion, aspect } = amode;
+        var { textSection, aspect } = amode;
         if(
-            theorion === 'claim'
+            textSection === 'claim'
         ) {
             [
                 'b',

--- a/contents/b1sec1lemma9/js/create-proof-slider.js
+++ b/contents/b1sec1lemma9/js/create-proof-slider.js
@@ -48,7 +48,7 @@
             sliderClassId       :'simple',
             captionScale        :captionScale,
             railsLegend         :'Process proof by decreasing AC:',
-            ancestorClassToHideSlider   :'theorion--claim',
+            ancestorClassToHideSlider   :'textSection--claim',
 
 
             dataInMove:         function( dataArg, draggee ) {

--- a/contents/b1sec1lemma9/js/media-upcreate.js
+++ b/contents/b1sec1lemma9/js/media-upcreate.js
@@ -157,10 +157,10 @@
         //api:calculateCurvedArea( rgId, pivots, tend, startPoint, endPoint )
         wCCA( 'area-Ace', medRemoteCurPivots,  tC, pointA.medpos, pointOe.medpos );
         wCCA( 'area-Abd', medRemoteCurPivots,  tB, pointA.medpos, pointOd.medpos );
-        paintCurvArea( 'area-Ace', 'theorion--proof', '_ace' );
+        paintCurvArea( 'area-Ace', 'textSection--proof', '_ace' );
         //.apparently makes this shape-element exclusively present in 
-        //.'theorion--proof' mode
-        paintCurvArea( 'area-Abd', 'theorion--proof', '_abd' );
+        //.'textSection--proof' mode
+        paintCurvArea( 'area-Abd', 'textSection--proof', '_abd' );
         //------------------------------------------
         //  \\// proof curved areas
         //------------------------------------------
@@ -180,8 +180,8 @@
         //------------------------------------------
         //  //\\ proof linear areas
         //------------------------------------------
-        paintLikeAGE( 'Age', 'theorion--proof', '_age', 'tostroke' );
-        paintLikeAGE( 'Afd', 'theorion--proof', '_afd', 'tostroke' );
+        paintLikeAGE( 'Age', 'textSection--proof', '_age', 'tostroke' );
+        paintLikeAGE( 'Afd', 'textSection--proof', '_afd', 'tostroke' );
         //------------------------------------------
         //  \\// proof linear areas
         //------------------------------------------

--- a/contents/b1sec2prop1/js/global-css-overrider.js
+++ b/contents/b1sec2prop1/js/global-css-overrider.js
@@ -19,7 +19,7 @@
         //1. .triangle-odd competes with
         //      .bsl-approot svg .tp-kepler-triangle.tofill
         //      we have to add more idle selectors into CSS-path,
-        //2.  overriding mask for theorion--claim ... .theor1proof
+        //2.  overriding mask for textSection--claim ... .theor1proof
         //      display ... none
         //--------------------------------------------------------
         globalCss.replace( `
@@ -32,24 +32,24 @@
                 display : none;
             }
 
-            .bsl-approot.appid-b1sec2prop1.theorion--claim svg .theor1claim,
-            .bsl-approot.appid-b1sec2prop1.theorion--corollary svg .theor1corollary,
-            .bsl-approot.appid-b1sec2prop2.theorion--corollary svg .theor2corollary,
-            .bsl-approot.appid-b1sec2prop2.theorion--proof svg .theor2proof,
-            .bsl-approot.appid-b1sec2prop1.theorion--proof svg .theor1proof
+            .bsl-approot.appid-b1sec2prop1.textSection--claim svg .theor1claim,
+            .bsl-approot.appid-b1sec2prop1.textSection--corollary svg .theor1corollary,
+            .bsl-approot.appid-b1sec2prop2.textSection--corollary svg .theor2corollary,
+            .bsl-approot.appid-b1sec2prop2.textSection--proof svg .theor2proof,
+            .bsl-approot.appid-b1sec2prop1.textSection--proof svg .theor1proof
             {
                 display : block;
             }
 
-            .bsl-approot.appid-b1sec2prop1.theorion--claim
+            .bsl-approot.appid-b1sec2prop1.textSection--claim
                 svg .theor1claim.undisplay,
-            .bsl-approot.appid-b1sec2prop1.theorion--corollary
+            .bsl-approot.appid-b1sec2prop1.textSection--corollary
                 svg .theor1corollary.undisplay,
-            .bsl-approot.appid-b1sec2prop2.theorion--corollary
+            .bsl-approot.appid-b1sec2prop2.textSection--corollary
                 svg .theor2corollary.undisplay,
-            .bsl-approot.appid-b1sec2prop2.theorion--proof
+            .bsl-approot.appid-b1sec2prop2.textSection--proof
                 svg .theor2proof.undisplay,
-            .bsl-approot.appid-b1sec2prop1.theorion--proof
+            .bsl-approot.appid-b1sec2prop1.textSection--proof
                 svg .theor1proof.undisplay
             {
                 display : none;
@@ -65,8 +65,8 @@
                 opacity : 0.7;
             }
 
-            div.bsl-approot.theorion--claim svg .tp-kepler-triangle.triangle-odd,
-            div.bsl-approot.theorion--claim svg .tp-kepler-triangle.triangle-even {
+            div.bsl-approot.textSection--claim svg .tp-kepler-triangle.triangle-odd,
+            div.bsl-approot.textSection--claim svg .tp-kepler-triangle.triangle-even {
                 fill : #8888ff;
                 opacity : 0.7;
             }

--- a/contents/b1sec2prop1/js/main-legend.js
+++ b/contents/b1sec2prop1/js/main-legend.js
@@ -302,11 +302,11 @@
 
         function makeCl(
                 row, mname, mcaption, spanIx, spanVal, alignCaptionToRight,
-                table_theorion, noEqualSign
+                table_textSection, noEqualSign
          ) {
             return makeClBoth(
                 row, mname, mcaption, spanIx, spanVal, alignCaptionToRight,
-                table_theorion, noEqualSign );
+                table_textSection, noEqualSign );
         }
     }
     //=========================================
@@ -327,7 +327,7 @@
     ///Input:  mname = magnitude name, just an ID of a cell and
     ///        tip for the css-class
     function makeClBoth( row, mname, mcaption, spanIx, spanVal,
-                         alignCaptionToRight, table_theorion, noEqualSign )
+                         alignCaptionToRight, table_textSection, noEqualSign )
     {
         var cssName = sDomF.topicIdUpperCase_2_underscore( mname );
 
@@ -358,7 +358,7 @@
                    .cls('tostroke tocolor tobold tp-'+cssName)
                    .to(row);
         if( spanIx === 2 ) { c$.a('colspan',''+spanVal); }
-        switch ( table_theorion ) {
+        switch ( table_textSection ) {
             case 'claim':
                 clustersToUpdate_claim[mname] = c$();
                 break;

--- a/contents/b1sec2prop1/js/media-model.js
+++ b/contents/b1sec2prop1/js/media-model.js
@@ -122,7 +122,7 @@
         if(
             amode.subessay === 'cor-1' ||
             amode.subessay === 'cor-6' ||
-            amode.theorion !== 'corollary'
+            amode.textSection !== 'corollary'
         ){
             rg.V.decStart = 11111111;
             rg.V.decEnd   = 1111111;
@@ -152,7 +152,7 @@
         }
 
         //:updates subessay menu
-        var exAspect = exegs[ amode.theorion ][ amode.aspect ];
+        var exAspect = exegs[ amode.textSection ][ amode.aspect ];
         var subexeg = exAspect.subessay2subexeg[ amode.subessay ];
         ////reveals subessay in menu and in text
         sDomF.addsChosenCSSCls_to_subessay8menuSubitem({ exAspect, subexeg })
@@ -202,22 +202,22 @@
             initialization_is_done = true;
             if( POINTS_BCDE_ARE_ACTIVE ) {
                 rg.B.svgel.addEventListener( 'click', function() {
-                    if( amode.theorion === 'proof' ) {
+                    if( amode.textSection === 'proof' ) {
                         fmethods.executeCapturedState( '1-4' );
                     }
                 });
                 rg.C.svgel.addEventListener( 'click', function() {
-                    if( amode.theorion === 'proof' ) {
+                    if( amode.textSection === 'proof' ) {
                         fmethods.executeCapturedState( '1-C' );
                     }
                 });
                 rg.D.svgel.addEventListener( 'click', function() {
-                    if( amode.theorion === 'proof' ) {
+                    if( amode.textSection === 'proof' ) {
                         fmethods.executeCapturedState( '1-D' );
                     }
                 });
                 rg.E.svgel.addEventListener( 'click', function() {
-                    if( amode.theorion === 'proof' ) {
+                    if( amode.textSection === 'proof' ) {
                         fmethods.executeCapturedState( '1-E' );
                     }
                 });
@@ -232,7 +232,7 @@
             }
         }
         var pointsAreOn = POINTS_BCDE_ARE_ACTIVE &&
-                          amode.theorion === 'proof';
+                          amode.textSection === 'proof';
         ['B', 'C', 'D', 'E'].forEach( id => {
                 let rgX = rg[ id ];
                 rgX.svgel.setAttribute( 'r', pointsAreOn ? '6' : '4' );
@@ -248,7 +248,7 @@
         //----------------------------------------------------        
         
         rg['main-legend'].tb.corollary.style.display =
-            ( amode.theorion === 'corollary' && amode.subessay === 'cor-1' ) ?
+            ( amode.textSection === 'corollary' && amode.subessay === 'cor-1' ) ?
             'table' : 'none';
 
         ssF.mediaModelInitialized = true;

--- a/contents/b1sec2prop1/js/sconf.js
+++ b/contents/b1sec2prop1/js/sconf.js
@@ -610,7 +610,7 @@
                     }
                 ],
                 [
-                    "( theorion === 'proof' )",
+                    "( textSection === 'proof' )",
                     {
                         "captured" : "1-0",
                         "rg" :
@@ -624,7 +624,7 @@
                 ],
 
                 [
-                    "( theorion === 'claim' && aspect !== 'model' )",
+                    "( textSection === 'claim' && aspect !== 'model' )",
                     {
                         "captured" : "initial-state",
                         "rg" :
@@ -634,7 +634,7 @@
                 ],
                  
                 [
-                    "( theorion === 'corollary' )",
+                    "( textSection === 'corollary' )",
                     {
                         "captured" : "initial-state",
                         "rg" :
@@ -787,7 +787,7 @@
                  
                 [
                     //"( fconf.sappId === 'b1sec2prop1' && subessay === 'cor-4' )",
-                    "( theorion === 'corollary' && aspect === 'model' )",
+                    "( textSection === 'corollary' && aspect === 'model' )",
                     {
                         //we set here condisions of cor4, but saggita will depend on time
                         //which is good for cor2

--- a/contents/b1sec2prop1/js/sets-user-touch-detector.js
+++ b/contents/b1sec2prop1/js/sets-user-touch-detector.js
@@ -25,8 +25,8 @@
     function subessayLaunch_definedInLemma_after_model_upcreate()
     {
         //this happens between "init_model_parameters" and "media_upcreate"
-        //var showBookDiagram = ( amode.theorion === 'claim' && amode.aspect !== 'model' ) ||
-        //                      ( amode.theorion !== 'corollary' )
+        //var showBookDiagram = ( amode.textSection === 'claim' && amode.aspect !== 'model' ) ||
+        //                      ( amode.textSection !== 'corollary' )
         sDomF.detected_user_interaction_effect( !!"showBookDiagram" );
     }
 

--- a/contents/b1sec2prop1/txt/addendum-comment.txt
+++ b/contents/b1sec2prop1/txt/addendum-comment.txt
@@ -11,11 +11,11 @@
          href="&#63;conf=sappId=addd-fw#Cframework">CalculusXX-framework:</a></b><br><br>
 
         <div style="text-align:center;">
-            <a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#area-speed">
+            <a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#area-speed">
                 <b>S˙˙</b> = 1/2[<b>ra</b>], and <br>
             </a>
 
-            <a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#theorem-ii">
+            <a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#theorem-ii">
                 <b>r</b>||<b>a</b> ⇒ S˙ = const
             </a>
         </div>
@@ -48,11 +48,11 @@
          href="&#63;conf=sappId=addd-fw#Cframework">CalculusXX-framework:</a></b><br><br>
 
         <div style="text-align:center;">
-            <a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#area-speed">
+            <a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#area-speed">
                 <b>S˙˙</b> = 1/2[<b>ra</b>], and <br>
             </a>
 
-            <a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#theorem-ii">
+            <a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#theorem-ii">
                 <b>r</b>||<b>a</b> ⇒ S˙ = const
             </a>
         </div>
@@ -171,7 +171,7 @@ To make speed and intial move distinct, we use these system simulation parameter
 
 <span class="captured-reference id-corollary-1">T.1. Corollary 1. </span>
         ¦SP¦r<sub>⟂</sub>¦¦v = const. <a target="_blank"  title="go to content"
-                href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#area-speed-vp">
+                href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#area-speed-vp">
             Proof.
             </a>
 <br><br>
@@ -181,7 +181,7 @@ To make speed and intial move distinct, we use these system simulation parameter
 <span class="captured-reference id-corollary-2">T.1. Corollary 2. </span>
 
 <a target="_blank"  title="go to content"
-   href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=calculus-xx#taylor-expansion-2">
+   href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=calculus-xx#taylor-expansion-2">
 From polynomial expansion at t₀ = ¦B¦¦ and ∆t = δ:
 </a>
 <br><br>

--- a/contents/b1sec2prop10/js/amode8captures.js
+++ b/contents/b1sec2prop10/js/amode8captures.js
@@ -49,7 +49,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         var media_scale = toreg( 'media_scale' )();
         rg.media_scale.value = 1;
         ssF.scaleValue2app( rg.media_scale.value, stdMod );
@@ -74,7 +74,7 @@
         rg[ 'tCircleCenter' ].undisplay = hideAnother;
 
         stdMod.medRoot$.css( 'display',
-            theorion === 'corollary' || theorion === 'scholium' ? 'none' : 'block'
+            textSection === 'corollary' || textSection === 'scholium' ? 'none' : 'block'
         )
 
         //=====================================================

--- a/contents/b1sec2prop10/js/main-legend.js
+++ b/contents/b1sec2prop10/js/main-legend.js
@@ -27,11 +27,11 @@
     {
         return;
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -88,11 +88,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -161,7 +161,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec2prop10/txt/cohen.txt
+++ b/contents/b1sec2prop10/txt/cohen.txt
@@ -61,7 +61,7 @@ Write
 and ¦Q¦¦ coming together) 2¦PO¦PC¦¦ for ¦vG¦𝑣G¦¦, and, multiplying the extremes and
 means together, ¦QT¦¦² x ¦PO¦PC¦¦² / ¦QR¦¦ will become equal to 2¦BO¦BC¦¦² x ¦AO¦CA¦¦² / ¦PO¦PC¦¦. Therefore
 
-(<a target="_blank" href="?conf=sappId=b1sec2prop6,theorionId=corollary,aspectId=english,subessayId=corollary5">by prop. 6, corol. 5</a>), the centripetal ¦force¦¦ is as 2¦BO¦BC¦¦² x ¦AO¦CA¦¦² / ¦PO¦PC¦¦ inversely, that
+(<a target="_blank" href="?conf=sappId=b1sec2prop6,textSectionId=corollary,aspectId=english,subessayId=corollary5">by prop. 6, corol. 5</a>), the centripetal ¦force¦¦ is as 2¦BO¦BC¦¦² x ¦AO¦CA¦¦² / ¦PO¦PC¦¦ inversely, that
 
 is (because 2¦BO¦BC¦¦² x ¦AO¦CA¦¦² is given), as 1/¦PO¦PC¦¦ inversely, that is, as the distance ¦PO¦PC¦¦
 directly. Q.E.I.
@@ -98,7 +98,7 @@ and the ratio of ¦u,VV¦𝑢V¦¦ to ¦vG¦𝑣G¦¦, which is the same as the 
 will become the ratio of ¦P,VV¦PV¦¦ to ¦GP¦PG¦¦ or ¦P,VV¦PV¦¦ to 2¦PO¦PC¦¦;
 and therefore ¦P,VV¦PV¦¦ will
 be equal to 2¦DO¦DC¦¦²/¦PO¦PC¦¦. Accordingly, the ¦force¦¦ under the action of which body ¦P¦¦
-revolves in the ellipse will (<a target="_blank" href="?conf=sappId=b1sec2prop6,theorionId=corollary,aspectId=english,subessayId=corollary3">by prop. 6, corol. 3</a>) be as 2¦DO¦DC¦¦² / ¦PO¦PC¦¦ x ¦PF¦¦² inversely,
+revolves in the ellipse will (<a target="_blank" href="?conf=sappId=b1sec2prop6,textSectionId=corollary,aspectId=english,subessayId=corollary3">by prop. 6, corol. 3</a>) be as 2¦DO¦DC¦¦² / ¦PO¦PC¦¦ x ¦PF¦¦² inversely,
 that is (because 2¦DO¦DC¦¦² x ¦PF¦¦² is given), as ¦PO¦PC¦¦ directly. Q.E.I.
 
 

--- a/contents/b1sec2prop2/js/sconf-addon.js
+++ b/contents/b1sec2prop2/js/sconf-addon.js
@@ -87,7 +87,7 @@
     "__amode2rgstate" :
     [
         [
-            "!ssF.mediaModelInitialized || amode.theorion === 'scholium' || amode.theorion === 'claim'",
+            "!ssF.mediaModelInitialized || amode.textSection === 'scholium' || amode.textSection === 'claim'",
             {
                 "captured" : "initial-state",
                 "rg" :
@@ -101,7 +101,7 @@
         ],
 
         [
-            "amode.theorion === 'proof'",
+            "amode.textSection === 'proof'",
             {
                 "rg" :
                 {
@@ -114,7 +114,7 @@
         ],
 
         [
-            "( theorion === 'corollary' )",
+            "( textSection === 'corollary' )",
             {
                 "captured" : "t2corollary",
                 "rg" :

--- a/contents/b1sec2prop2/js/study-model-addon.js
+++ b/contents/b1sec2prop2/js/study-model-addon.js
@@ -32,15 +32,15 @@
     function model_upcreate_addon()
     {
         //this patch amends this css
-        //.bsl-approot.theorion--corollary.aspect--english .bsl--svgscene.s ubmodel-common
+        //.bsl-approot.textSection--corollary.aspect--english .bsl--svgscene.s ubmodel-common
 
-        //img competes with: .bsl-approot.theorion--scholium.aspect--english .bg0,
+        //img competes with: .bsl-approot.textSection--scholium.aspect--english .bg0,
         //todm: inconsistent: .main-legend.proof should not need this CSS, it
         //      is designed to remove itself by class ".proof",
         var wwCss =
             amode.aspect === 'model' ||
-            amode.theorion === 'corollary' ||
-            amode.theorion === 'scholium'
+            amode.textSection === 'corollary' ||
+            amode.textSection === 'scholium'
         ?
         //hides common model in corollary and scholium
         `

--- a/contents/b1sec2prop2/txt/addendum-comment.txt
+++ b/contents/b1sec2prop2/txt/addendum-comment.txt
@@ -16,7 +16,7 @@
 *..*
 
 
-<a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#theorem-2">
+<a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#theorem-2">
     <b>S˙</b> = const ⇔ [<b>ra</b>] = 0</a>.
 </a>
 <br><br>
@@ -112,7 +112,7 @@ the height of ¦SBC¦triangle SBC¦¦ and decreases area speed.
 
 
 Corollary 1.
-    <a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#corollary-1">
+    <a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#corollary-1">
     <b>S˙˙</b><sub>z</sub> ⇈ <b>S˙</b><sub>z</sub> ⇔
     <b>a</b><sub>⟂</sub> ⇈ <b>v</b><sub>⟂</sub>.
 </a>
@@ -121,7 +121,7 @@ Corollary 1.
 
 
 Corollary 2.
-    <a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#corollary-2">
+    <a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#corollary-2">
 <i>a</i><sub>⟂</sub> = -d + <i>f</i><sub>⟂</sub>.
     </a>
 <br><br>
@@ -137,7 +137,7 @@ Corollary 2.
 }
 *..*
 
-<a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=areas#scholium">
+<a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=areas#scholium">
 
 <b>a</b><sub>z</sub> does not contribute to area.
 

--- a/contents/b1sec2prop6/js/amode8captures.js
+++ b/contents/b1sec2prop6/js/amode8captures.js
@@ -48,7 +48,7 @@
 
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         
         sconf.originalPoints.foldPoints.forEach( (fp,ppix) => {
             fp.rgX.undisplay = true;
@@ -111,7 +111,7 @@
 
         } else {
 
-            if( theorion === 'claim' || theorion === 'proof' ){
+            if( textSection === 'claim' || textSection === 'proof' ){
 
                 rg.media_scale.value = 1;
 
@@ -148,10 +148,10 @@
                     )
                 );
                 */
-                if( theorion === 'proof' ){
+                if( textSection === 'proof' ){
                     rg[ 'Q,rrminus' ].undisplay = false;
                 }
-            } else if( theorion === 'corollary' && aspect === 'addendum' &&
+            } else if( textSection === 'corollary' && aspect === 'addendum' &&
                     subessay === 'corollary1' ){
                 rg.SY.undisplay = true;
                 rg.Y.undisplay = true;
@@ -165,7 +165,7 @@
                 rg[ 'Q,rrminus' ].undisplay = false;
                 rg[ 'P,rrminus' ].undisplay = false;
 
-            } else if( theorion === 'corollary' && subessay === 'corollary1' ){
+            } else if( textSection === 'corollary' && subessay === 'corollary1' ){
                 rg.SY.undisplay = true;
                 rg.Y.undisplay = true;
                 rg.PY.undisplay = true;
@@ -180,7 +180,7 @@
                 //rg.sagitta.undisplay = false;
                 rg[ 'P,sagitta' ].undisplay = false;
 
-            } else if( theorion === 'corollary' && subessay === 'corollary3'
+            } else if( textSection === 'corollary' && subessay === 'corollary3'
             ){
                 if( aspect === 'addendum' ) {
                     rg.Q.hideD8Dpoint = true;
@@ -214,7 +214,7 @@
                 rg.timearc.undisplay = true;
 
 
-            } else if( theorion === 'corollary' && subessay === 'corollary5' ){
+            } else if( textSection === 'corollary' && subessay === 'corollary5' ){
                 rg.SY.undisplay = true;
                 rg.Y.undisplay = true;
                 rg.PY.undisplay = false;

--- a/contents/b1sec2prop6/js/main-legend.js
+++ b/contents/b1sec2prop6/js/main-legend.js
@@ -21,12 +21,12 @@
 
     function create_digital_legend()
     {
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'claim' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'claim' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //sample:
         //let sagittaColor = sDomF.getFixedColor( 'sagitta' ).replace( / /g, '<_>' ).replace( /,/g, '<>' );
@@ -66,11 +66,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : '',
             noTableTitle    : true,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -103,7 +103,7 @@
             })
         }
         
-        function createsIdleFirstRow_forFormat( tb, theorion )
+        function createsIdleFirstRow_forFormat( tb, textSection )
         {
             //=====================================================
             // //\\ idle first row to format table for fixed-layout
@@ -111,7 +111,7 @@
             var row = $$.c('tr')
                 //vital ... removes global css which corrupts table
                 //aka .addClass( 'proof row1 tostroke' )
-                .addClass( theorion +' tostroke')
+                .addClass( textSection +' tostroke')
 
                 .css( 'visibility', 'hidden' ) //todm ... tmp fix
                 .to(tb)
@@ -127,7 +127,7 @@
         
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec2prop6/txt/addendum.txt
+++ b/contents/b1sec2prop6/txt/addendum.txt
@@ -36,7 +36,7 @@ Force
 
 where ¦P,sagitta¦sagitta 𝕻 ¦¦
 
-<a target="_blank" href="?conf=sappId=b1sec2prop1,theorionId=corollary,aspectId=model,subessayId=0#sagitta">
+<a target="_blank" href="?conf=sappId=b1sec2prop1,textSectionId=corollary,aspectId=model,subessayId=0#sagitta">
 is defined here</a>,
 <br><br>
 
@@ -65,13 +65,13 @@ Force
 
 where ¦P,sagitta¦sagitta 𝕻 ¦¦
 
-<a target="_blank" href="?conf=sappId=b1sec2prop1,theorionId=corollary,aspectId=model,subessayId=0#sagitta">
+<a target="_blank" href="?conf=sappId=b1sec2prop1,textSectionId=corollary,aspectId=model,subessayId=0#sagitta">
 is defined here</a>,
 
 M/2 is "Kepler constant" for constant sectorial speed:
     <div style="text-align:center;">
         S˙ = 1/2[<b>rₒvₒ</b>]<sub>𝗸</sub> = M/2, <br>
-        where 𝗸 = <a target="_blank" href="?conf=sappId=addd-prel-curveXX,theorionId=proof,aspectId=curve,subessayId=calculus-xx">[𝗶𝗷].</a>
+        where 𝗸 = <a target="_blank" href="?conf=sappId=addd-prel-curveXX,textSectionId=proof,aspectId=curve,subessayId=calculus-xx">[𝗶𝗷].</a>
     </div>
 <br><br><br>
 

--- a/contents/b1sec2prop6/txt/english.txt
+++ b/contents/b1sec2prop6/txt/english.txt
@@ -25,13 +25,13 @@ ratio of the time].
 
 For the ¦P,sagitta¦the sagitta¦¦ in the ¦dtime¦given time¦¦ is as the ¦force¦¦
 
-(<a target="_blank" href="?conf=sappId=b1sec2prop1,theorionId=corollary,aspectId=english,subessayId=cor-4">by Proposition 1 Corollary 4</a>),
+(<a target="_blank" href="?conf=sappId=b1sec2prop1,textSectionId=corollary,aspectId=english,subessayId=cor-4">by Proposition 1 Corollary 4</a>),
 
 and by increasing ¦dtime¦the time¦¦ in any ratio you please, because ¦timearc¦the arc¦¦
 increases in the same ratio, the ¦P,sagitta¦the sagitta¦¦ is increased in the
 duplicate of that ratio
 
-(<a target="_blank" href="?conf=sappId=b1sec1lemma11,theorionId=corollary,aspectId=english,subessayId=0">by Lemma 11 Corollary 2 and 3</a>).
+(<a target="_blank" href="?conf=sappId=b1sec1lemma11,textSectionId=corollary,aspectId=english,subessayId=0">by Lemma 11 Corollary 2 and 3</a>).
 
 Therefore, it is as the ¦force¦¦ once and ¦dtime¦the time¦¦ twice. Let the duplicate ratio of
 ¦dtime¦the time¦¦ be removed on both sides, and the ¦force¦¦ comes out to be as the ¦P,sagitta¦sagitta¦¦
@@ -41,7 +41,7 @@ Q.E.D.
 <br><br>
 The same thing is also easily demonstrated
 
-(<a target="_blank" href="?conf=sappId=b1sec1lemma10,theorionId=corollary,aspectId=english,subessayId=0">by Lemma 10 Corollary 4</a>).
+(<a target="_blank" href="?conf=sappId=b1sec1lemma10,textSectionId=corollary,aspectId=english,subessayId=0">by Lemma 10 Corollary 4</a>).
 
 <br><br>
 <div book-reference-id="Donahue"></div>

--- a/contents/b1sec2prop7/js/amode8captures.js
+++ b/contents/b1sec2prop7/js/amode8captures.js
@@ -48,7 +48,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
 
         //----------------------------------
         // //\\ common values

--- a/contents/b1sec2prop7/js/main-legend.js
+++ b/contents/b1sec2prop7/js/main-legend.js
@@ -27,11 +27,11 @@
     {
         return;
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -88,11 +88,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -161,7 +161,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec2prop7/txt/addendum.txt
+++ b/contents/b1sec2prop7/txt/addendum.txt
@@ -34,7 +34,7 @@ In Vector Calculus for Excentric circular motion,</a>
 
 *::*corollary|addendum
 {
-  "theorionCaption" : "Corollaries",
+  "textSectionCaption" : "Corollaries",
   "menuCaption" : "Addendum",
   "subessayCaption" : "Corollary 1",
   "subessay" : "corollary1"
@@ -51,7 +51,7 @@ In Vector Calculus <a target="_blank" href="?conf=sappId=addd-kepler-task#excent
 
 *::*corollary|addendum
 {
-  "theorionCaption" : "Corollaries",
+  "textSectionCaption" : "Corollaries",
   "menuCaption" : "---",
   "subessayCaption" : "Corollary 3",
   "subessay" : "corollary3"
@@ -59,7 +59,7 @@ In Vector Calculus <a target="_blank" href="?conf=sappId=addd-kepler-task#excent
 *..*
 
 
-In Vector Calculus <a target="_blank" href="?conf=sappId=addd-kepler-task,theorionId=proof,aspectId=addendum,subessayId=force-center-change">
+In Vector Calculus <a target="_blank" href="?conf=sappId=addd-kepler-task,textSectionId=proof,aspectId=addendum,subessayId=force-center-change">
     section "Two force fields ... ", (ft)</a> gives: 
 <br>
 

--- a/contents/b1sec2prop7/txt/cohen.txt
+++ b/contents/b1sec2prop7/txt/cohen.txt
@@ -1,7 +1,7 @@
 
 *::*proof|english
 {
-  "theorionCaption" : "Problem 2",
+  "textSectionCaption" : "Problem 2",
   "default" : "1",
   "menuCaption" : "Text"
 }

--- a/contents/b1sec2prop9/js/amode8captures.js
+++ b/contents/b1sec2prop9/js/amode8captures.js
@@ -49,7 +49,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         var media_scale = toreg( 'media_scale' )();
         rg.media_scale.value = 1;
         ssF.scaleValue2app( rg.media_scale.value, stdMod );

--- a/contents/b1sec2prop9/js/main-legend.js
+++ b/contents/b1sec2prop9/js/main-legend.js
@@ -27,11 +27,11 @@
     {
         return;
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -88,11 +88,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -161,7 +161,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec2prop9/txt/cohen.txt
+++ b/contents/b1sec2prop9/txt/cohen.txt
@@ -36,7 +36,7 @@ will be changed (by lem. 11) as the square of ¦PR¦¦ or ¦QT¦¦. Therefore,
 will remain the same as before, that is, as ¦SP¦¦. And therefore ¦QT¦¦² x ¦SP¦¦² / ¦QR¦¦
 is as ¦SP¦¦³, and thus
 
-<a target="_blank" href="?conf=sappId=b1sec2prop6,theorionId=corollary,aspectId=english,subessayId=corollary1">
+<a target="_blank" href="?conf=sappId=b1sec2prop6,textSectionId=corollary,aspectId=english,subessayId=corollary1">
 (by prop. 6, corols. 1 and 5)
 </a>,
 
@@ -53,7 +53,7 @@ are to the distance ¦SP¦¦ in given ratios;
 and thus ¦SP¦¦³ is as ¦SY¦¦² x ¦PV¦¦,
 that is
 
-<a target="_blank" href="?conf=sappId=b1sec2prop6,theorionId=corollary,aspectId=english,subessayId=corollary3">
+<a target="_blank" href="?conf=sappId=b1sec2prop6,textSectionId=corollary,aspectId=english,subessayId=corollary3">
 (by prop. 6, corols. 3 and 5)
 </a>,
 

--- a/contents/b1sec3lemma13/js/amode8captures.js
+++ b/contents/b1sec3lemma13/js/amode8captures.js
@@ -49,7 +49,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         var media_scale = toreg( 'media_scale' )();
         rg.media_scale.value = 1;
         ssF.scaleValue2app( rg.media_scale.value, stdMod );

--- a/contents/b1sec3lemma13/js/main-legend.js
+++ b/contents/b1sec3lemma13/js/main-legend.js
@@ -27,11 +27,11 @@
     {
         return;
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -88,11 +88,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -161,7 +161,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec3lemma14/js/amode8captures.js
+++ b/contents/b1sec3lemma14/js/amode8captures.js
@@ -49,7 +49,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         var media_scale = toreg( 'media_scale' )();
         rg.media_scale.value = 1;
         ssF.scaleValue2app( rg.media_scale.value, stdMod );

--- a/contents/b1sec3lemma14/js/main-legend.js
+++ b/contents/b1sec3lemma14/js/main-legend.js
@@ -27,11 +27,11 @@
     {
         return;
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -88,11 +88,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -161,7 +161,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec3prop11/js/amode8captures.js
+++ b/contents/b1sec3prop11/js/amode8captures.js
@@ -49,7 +49,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         var media_scale = toreg( 'media_scale' )();
         rg.media_scale.value = 1;
         ssF.scaleValue2app( rg.media_scale.value, stdMod );
@@ -169,7 +169,7 @@
             rg.tangentCircle.undisplay = hideAnother;
 
             stdMod.medRoot$.css( 'display',
-                theorion === 'corollary' || theorion === 'scholium' ? 'none' : 'block'
+                textSection === 'corollary' || textSection === 'scholium' ? 'none' : 'block'
             )
 
             //hides prop11

--- a/contents/b1sec3prop11/js/main-legend.js
+++ b/contents/b1sec3prop11/js/main-legend.js
@@ -27,11 +27,11 @@
     {
         return;
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -88,11 +88,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -161,7 +161,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec3prop11/txt/addendum.txt
+++ b/contents/b1sec3prop11/txt/addendum.txt
@@ -27,7 +27,7 @@
 <b><i>Another Solution</i></b>
 <br>
 
-<a target="_blank" href="?conf=sappId=addd-kepler-task,theorionId=proof,aspectId=addendum,subessayId=force-center-change">
+<a target="_blank" href="?conf=sappId=addd-kepler-task,textSectionId=proof,aspectId=addendum,subessayId=force-center-change">
     Transitional formula (ft)</a> gives: 
 <br>
 
@@ -42,7 +42,7 @@
                  𝑓<sub>φ</sub> = 𝑠M²α²β²ρ<sub>φ</sub>. <br>
     </div>
 and recalling conic's property 𝘨  = 𝜎𝑠a,
-<a target="_blank" href="?conf=sappId=addd-conics,theorionId=proof,aspectId=addendum,subessayId=interval#ellipse">
+<a target="_blank" href="?conf=sappId=addd-conics,textSectionId=proof,aspectId=addendum,subessayId=interval#ellipse">
 from "Interval between conjugate parallels", (A),
 </a>
 we obtain the inverse square law again: 𝑓  = 𝑓 <sub>𝛙</sub> and

--- a/contents/b1sec3prop11/txt/cohen.txt
+++ b/contents/b1sec3prop11/txt/cohen.txt
@@ -37,7 +37,7 @@ L x ¦Pv¦P𝑣¦¦ will be to ¦vG¦G𝑣¦¦ x ¦Pv¦𝑣P¦¦ as
 L to ¦vG¦G𝑣¦¦; and<sup>b</sup>
  ¦vG¦G𝑣¦¦ x ¦Pv¦vP¦¦ will be to ¦Qv¦Q𝑣¦¦²
  as PC² to CD²; and
-(<a target="_blank" href="?conf=sappId=b1sec1lemma7,theorionId=corollary,aspectId=english">by lem. 7, corol. 2</a>)
+(<a target="_blank" href="?conf=sappId=b1sec1lemma7,textSectionId=corollary,aspectId=english">by lem. 7, corol. 2</a>)
 
 the ratio of ¦Qv¦Q𝑣¦¦² to ¦Qx¦Q𝑥¦¦²,
 with the points ¦Q¦¦ and ¦P¦¦ coming together, is the
@@ -62,7 +62,7 @@ are proportional to these, are also equal. Multiply these equals by , and
 L x ¦SP¦¦²
  will become equal to . Therefore
 
-(<a target="_blank" href="?conf=sappId=b1sec2prop6,theorionId=corollary,aspectId=english,subessayId=corollary1">by prop. 6, corols, 1 and 5
+(<a target="_blank" href="?conf=sappId=b1sec2prop6,textSectionId=corollary,aspectId=english,subessayId=corollary1">by prop. 6, corols, 1 and 5
 </a>)
 
 
@@ -90,7 +90,7 @@ Page 462.
 The ¦force¦¦ which tends toward ¦O¦the center¦¦ of ¦orbit¦the ellipse¦¦, and by which
 ¦P¦body P¦¦ can revolve in ¦orbit¦that ellipse¦¦, is
 
-(<a target="_blank" href="?conf=sappId=b1sec2prop10,theorionId=corollary,aspectId=english">(by prop. 10, corol. 1)</a>)
+(<a target="_blank" href="?conf=sappId=b1sec2prop10,textSectionId=corollary,aspectId=english">(by prop. 10, corol. 1)</a>)
 
 as the distance ¦PO¦CP¦¦
 of the body from the ¦O¦center C¦¦ of the ellipse; hence, if ¦EO¦CE¦¦ is drawn parallel to
@@ -98,7 +98,7 @@ the tangent ¦PR¦¦ of the ellipse and if ¦EO¦CE¦¦ and ¦SP¦PS¦¦ meet at
 which the same ¦P¦body P¦¦ can revolve around any other ¦S¦point S¦¦ of the ellipse
 will
  
-(<a target="_blank" href="?conf=sappId=b1sec2prop7,theorionId=corollary,aspectId=english,subessayId=corollary3">
+(<a target="_blank" href="?conf=sappId=b1sec2prop7,textSectionId=corollary,aspectId=english,subessayId=corollary3">
 (by prop. 7, corol. 3)</a>)
 
 

--- a/contents/b1sec3prop12/js/amode8captures.js
+++ b/contents/b1sec3prop12/js/amode8captures.js
@@ -49,7 +49,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         //------------------------------------------------
         // //\\ returns diagram back at every menu click
         //      todm: this is a patch: do streamline
@@ -338,7 +338,7 @@
             rg.L.hideD8Dpoint = false;
             stdMod.imgRk.dom$.css( 'visibility', 'visible' );
             stdMod.svgScene$.css( 'visibility', 'visible' );
-            if( theorion === 'corollary' ) {
+            if( textSection === 'corollary' ) {
                 if( subessay === "corollary1" ) {
                     ////latus on others: swaps latus and speed
                     rg.vb.hideD8Dpoint = false;
@@ -449,7 +449,7 @@
                 rg.omegaHandle.hideD8Dpoint = false;
                 rg.f.caption = '𝛾';
             }
-            if( theorion === 'scholium' ||
+            if( textSection === 'scholium' ||
                     ( amode.subessay === 'corollary3' || amode.subessay === 'corollary4' )
             ){
                 var imgVisib = 'hidden';
@@ -464,7 +464,7 @@
             }
             stdMod.imgRk.dom$.css( 'visibility', imgVisib );
             stdMod.svgScene$.css( 'visibility', imgVisib );
-            if( theorion === 'corollary' && amode.subessay === 'corollary2' ){
+            if( textSection === 'corollary' && amode.subessay === 'corollary2' ){
                 rg.vSample.hideD8Dpoint = true;
             }
             //-------------------------------------------------
@@ -495,7 +495,7 @@
         stdMod.establishesEccentricity( op.initialEccentricity )
         if( fconf.sappId === "b1sec3prop17" ) {
             op.PparQ_initial = op.PparQ_initial_essay
-            if( theorion === 'corollary' &&
+            if( textSection === 'corollary' &&
                 ( amode.subessay === 'corollary1' || amode.subessay === 'corollary2' )
             ){
                 op.PparQ_initial = 0;
@@ -546,7 +546,7 @@
             //-------------------------------------------------
             op.cosOmega = op.cosOmega_initial;
             op.om       = op.om_initial;
-            if( theorion === 'corollary' &&
+            if( textSection === 'corollary' &&
                 ( amode.subessay === 'corollary1' || amode.subessay === 'corollary2' )
             ){
                 op.om = 1;
@@ -578,7 +578,7 @@
             sop.Kepler_v = sop.Kepler_v_initial;
             sop.cosOmega = sop.cosOmega_initial;
             sop.om       = sop.om_initial;
-            if( theorion === 'corollary' && amode.subessay === 'corollary2' ){
+            if( textSection === 'corollary' && amode.subessay === 'corollary2' ){
                 sop.om = 1;
                 sop.cosOmega = 0;
                 sop.latus = sop.corII_DVect.abs;

--- a/contents/b1sec3prop12/js/completes-sliders-creation.js
+++ b/contents/b1sec3prop12/js/completes-sliders-creation.js
@@ -127,7 +127,7 @@
         };
 
         rg.L.acceptPos = ( newPos, dragMove ) => {
-            var { theorion, aspect, subessay } = amode;
+            var { textSection, aspect, subessay } = amode;
 
             var newPos0 = dragMove[0] + sData.Lpos0;
             var newPos1 = -dragMove[1] + sData.Lpos1;
@@ -136,7 +136,7 @@
             var dS     = Math.abs( dShift[0]*dShift[0] + dShift[1]*dShift[1] );
             if( dS < 0.00000001 ) return;
             var incr   = dS / sData.dShift;
-            if( theorion === 'claim' || theorion === 'proof' ||
+            if( textSection === 'claim' || textSection === 'proof' ||
                 fconf.sappId === 'b1sec3prop15'
             ){
                 //speed on latus, omega = const
@@ -217,7 +217,7 @@
         };
 
         rg.f.acceptPos = ( newPos, dragMove ) => {
-            var { theorion, aspect, subessay } = amode;
+            var { textSection, aspect, subessay } = amode;
             var newPos0 = dragMove[0] *
                           0.5 //decreases slider sensetivity
                          + sData.Lpos0_g;
@@ -330,7 +330,7 @@
         };
 
         rg.vb.acceptPos = ( newPos, dragMove ) => {
-            var { theorion, aspect, subessay } = amode;
+            var { textSection, aspect, subessay } = amode;
             var newPos0  = dragMove[0] + sData.vbpos[0];
             var newPos1  = -dragMove[1] + sData.vbpos[1];
             //-------------------------------------------------------------------
@@ -431,7 +431,7 @@
         };
 
         rg.omegaHandle.acceptPos = ( newPos, dragMove ) => {
-            var { theorion, aspect, subessay } = amode;
+            var { textSection, aspect, subessay } = amode;
             //-------------------------------------------------------------------
             // //\\ corrects approximate mouse point to exact point on the circle
             //-------------------------------------------------------------------
@@ -549,7 +549,7 @@
         };
 
         rg.vSample.acceptPos = ( newPos, dragMove ) => {
-            var { theorion, aspect, subessay } = amode;
+            var { textSection, aspect, subessay } = amode;
             const pp      = rg.p.pos;
             let np        = nspaste( [], [
                                 dragMove[0] + sData.pos_r[0],

--- a/contents/b1sec3prop12/js/main-legend.js
+++ b/contents/b1sec3prop12/js/main-legend.js
@@ -27,11 +27,11 @@
     {
         return;
         //see lemma 11 for the sample
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -88,11 +88,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -161,7 +161,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b1sec3prop12/txt/addendum.txt
+++ b/contents/b1sec3prop12/txt/addendum.txt
@@ -33,7 +33,7 @@ It is evident that ¦EP¦¦ is
 <br><br>
 
 b. This result is given in <i>Source</i>, prop. 10 with reference to "the Conies"; see the Guide, §10.10.
-[<a target="_blank" href="?conf=sappId=addd-conics,theorionId=proof,aspectId=addendum,subessayId=interval#in-focus">
+[<a target="_blank" href="?conf=sappId=addd-conics,textSectionId=proof,aspectId=addendum,subessayId=interval#in-focus">
 and in CalculusXX, (A)</a>
 ]
 <br><br>
@@ -55,7 +55,7 @@ from the other ¦H¦focus H¦¦ of the hyperbola, ¦ES¦¦ and ¦EI¦¦ are equa
 }
 *..*
 
-<a target="_blank" href="?conf=sappId=addd-kepler-task,theorionId=proof,aspectId=addendum,subessayId=force-center-change">
+<a target="_blank" href="?conf=sappId=addd-kepler-task,textSectionId=proof,aspectId=addendum,subessayId=force-center-change">
     Transitional formula (ft)</a> gives: 
 <br>
 
@@ -71,7 +71,7 @@ from the other ¦H¦focus H¦¦ of the hyperbola, ¦ES¦¦ and ¦EI¦¦ are equa
                      𝑓<sub>𝛙</sub> = 𝑠M²α²β²ρ<sub>𝛙</sub>. <br>
     </div>
 
-and <a target="_blank" href="?conf=sappId=addd-conics,theorionId=proof,aspectId=addendum,subessayId=interval#ellipse">
+and <a target="_blank" href="?conf=sappId=addd-conics,textSectionId=proof,aspectId=addendum,subessayId=interval#ellipse">
 recalling conic's property (A),
 </a>
     <div style="text-align:center;">

--- a/contents/b1sec3prop12/txt/cohen.txt
+++ b/contents/b1sec3prop12/txt/cohen.txt
@@ -29,11 +29,11 @@ ordinate to the diameter ¦GP¦¦. Draw ¦SP¦¦ cutting diameter DK in ¦E¦¦ 
 <!--
 <br><br>
 b.
-<a target="_blank" href="?conf=sappId=addd-conics,theorionId=proof,aspectId=addendum,subessayId=interval#in-focus">
+<a target="_blank" href="?conf=sappId=addd-conics,textSectionId=proof,aspectId=addendum,subessayId=interval#in-focus">
 This result</a>
 
 is given in <a href="#cohensource"><i>Source</i></a>, prop. 10 with reference to "the Conies"; see the Guide, §10.10.
-[<a target="_blank" href="?conf=sappId=addd-conics,theorionId=proof,aspectId=addendum,subessayId=interval#in-focus">
+[<a target="_blank" href="?conf=sappId=addd-conics,textSectionId=proof,aspectId=addendum,subessayId=interval#in-focus">
 and in CalculusXX, (A)</a>
 ]
 <br><br>
@@ -55,7 +55,7 @@ or ¦CA¦AC¦¦ to ¦PC¦¦. L x ¦Pv¦P𝑣¦¦ will also be to ¦Gv¦G𝑣¦¦
 
 nature of conics) the rectangle ¦Gv¦G𝑣¦¦ x ¦Pv¦𝑣P¦¦ will be to ¦Qv¦Q𝑣¦¦² as ¦PC¦¦² to ¦CD¦¦²; and
 (
-<a target="_blank" href="?conf=sappId=b1sec1lemma7,theorionId=corollary,aspectId=english">
+<a target="_blank" href="?conf=sappId=b1sec1lemma7,textSectionId=corollary,aspectId=english">
 by lem. 7, corol. 2</a>
 )
 the ratio of ¦Qv¦Q𝑣¦¦² to ¦Qx¦Q𝑥¦¦², the points ¦Q¦¦ and ¦P¦¦ coming
@@ -92,7 +92,7 @@ Page 465.
 Find the force that tends from the center ¦C¦¦ of ¦orbit¦the hyperbola¦¦. This will
 come out proportional to the distance ¦PC¦CP¦¦. And hence
 (
-<a target="_blank" href="?conf=sappId=b1sec2prop7,theorionId=corollary,aspectId=english,subessayId=corollary3">
+<a target="_blank" href="?conf=sappId=b1sec2prop7,textSectionId=corollary,aspectId=english,subessayId=corollary3">
 by prop. 7, corol. 3</a>
 )
 the force tending toward the focus ¦S¦¦ will be as ¦PE¦¦³/¦SP¦¦², that is, because ¦PE¦¦ is

--- a/contents/b1sec3prop14/txt/addendum.txt
+++ b/contents/b1sec3prop14/txt/addendum.txt
@@ -6,7 +6,7 @@
 
 
 <b>In <><>CXX:</b><br>
-<a target="_blank" href="?conf=sappId=b1sec3prop14,theorionId=proof,aspectId=addendum">
+<a target="_blank" href="?conf=sappId=b1sec3prop14,textSectionId=proof,aspectId=addendum">
 From proof addendum (S):
 </a>
 

--- a/contents/b1sec3prop14/txt/cohen.txt
+++ b/contents/b1sec3prop14/txt/cohen.txt
@@ -38,7 +38,7 @@ Page 113.
 
 For
 
-<a target="_blank" href="?conf=sappId=b1sec3prop13,theorionId=corollary,aspectId=english,subessayId=corollary2">
+<a target="_blank" href="?conf=sappId=b1sec3prop13,textSectionId=corollary,aspectId=english,subessayId=corollary2">
 (by prop. 13, corol. 2)
 </a>
 

--- a/contents/b1sec3prop15/txt/addendum.txt
+++ b/contents/b1sec3prop15/txt/addendum.txt
@@ -33,7 +33,7 @@ Page 114.
 <b>In <><>CXX:</b><br>
 
 From "physics"
-<a target="_blank" href="?conf=sappId=b1sec3prop14,theorionId=proof,aspectId=addendum">
+<a target="_blank" href="?conf=sappId=b1sec3prop14,textSectionId=proof,aspectId=addendum">
  assuming 𝛾 is the same for all orbits, (S)
 </a>
 

--- a/contents/b1sec3prop16/txt/addendum.txt
+++ b/contents/b1sec3prop16/txt/addendum.txt
@@ -43,5 +43,5 @@ Therefore:
 }
 *..*
 
-<b>Corollary 1: <><>CXX:</b> <a target="_blank" href="?conf=sappId=b1sec3prop16,theorionId=proof,aspectId=addendum">see addendum for proof</a>
+<b>Corollary 1: <><>CXX:</b> <a target="_blank" href="?conf=sappId=b1sec3prop16,textSectionId=proof,aspectId=addendum">see addendum for proof</a>
 

--- a/contents/b1sec3prop17/txt/addendum.txt
+++ b/contents/b1sec3prop17/txt/addendum.txt
@@ -379,7 +379,7 @@ L (χ SP + PH ) = 2 PH .( χ KP + SP ) <br>
                                         </td><td>
 (χr₊ + r₋) / r₋ = (2χ𝗿₊𝗲₋ + 2r₊) / L = <br>
 = 
-<a target="_blank" href="?conf=sappId=addd-conics,theorionId=proof,aspectId=addendum,subessayId=shoulder-lemma#conics">
+<a target="_blank" href="?conf=sappId=addd-conics,textSectionId=proof,aspectId=addendum,subessayId=shoulder-lemma#conics">
 4Ω²r₊
 </a>
 

--- a/contents/b1sec5lemma20/js/sconf.js
+++ b/contents/b1sec5lemma20/js/sconf.js
@@ -129,49 +129,49 @@
             // //\\ aux points
             G : {
                    pcolor : pt.aux,
-                   cssClass : 'theorion--proof',
+                   cssClass : 'textSection--proof',
                    letterAngle : 45,
                  },
             I : {
                    pcolor : pt.aux,
-                   cssClass : 'theorion--proof',
+                   cssClass : 'textSection--proof',
                    letterAngle : -125,
                    letterRotRadius : 20,
                  },
             H : {
                    pcolor : pt.aux,
-                   cssClass : 'theorion--proof',
+                   cssClass : 'textSection--proof',
                    letterAngle : -90,
                    letterRotRadius : 20,
                  },
             E : {
                    pcolor : pt.aux,
-                   cssClass : 'theorion--proof',
+                   cssClass : 'textSection--proof',
                    letterAngle : -125,
                    letterRotRadius : 20,
                  },
             K : {
                    pcolor : pt.aux,
-                   cssClass : 'theorion--proof',
+                   cssClass : 'textSection--proof',
                    letterAngle : 90,
                    letterRotRadius : 20,
                 },
             F : {
                    pcolor : pt.aux,
-                   cssClass : 'theorion--proof',
+                   cssClass : 'textSection--proof',
                    letterAngle : 0,
                    letterRotRadius : 20,
                 },
             t : { pos: [1511, 574],
                   pcolor : pt.aux,
-                  cssClass : 'theorion--proof',
+                  cssClass : 'textSection--proof',
                   initialR: pointRadius,
                   letterAngle : 45,
                   letterRotRadius : 20,
                 },
             r : { pos: [1028, 830],
                   pcolor : pt.aux,
-                  cssClass : 'theorion--proof',
+                  cssClass : 'textSection--proof',
                   initialR: pointRadius,
                 },
             q : { pos: [1028, 830],
@@ -407,58 +407,58 @@
             //------------------------
             { 'DG' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                      }
             },
             { 'IG' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                      }
             },
 
             { 'DI' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                      }
             },
             { 'DE' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                      }
             },
             { 'DK' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                      }
             },
             { 'Bt' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                     }
             },
             { 'CF' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                     }
             },
             { 'HB' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                     }
             },
             { 'DH' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                     }
             },
             { 'DF' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                     }
             },
             { 'IQ' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                     }
             },
             //------------------------
@@ -470,7 +470,7 @@
             //------------------------
             { 'rt' : {
                         pcolor : pt.aux,
-                        cssClass : 'theorion--proof',
+                        cssClass : 'textSection--proof',
                     }
             },
             { 'Pr' : {

--- a/contents/b1sec5lemma21/js/sconf.js
+++ b/contents/b1sec5lemma21/js/sconf.js
@@ -207,7 +207,7 @@
                   pos: pop.O,
                   //pcolor: pt[ "g-parameter" ],
                   //cssClass: 'tp-static',
-                  //cssClass : 'theorion--proof',
+                  //cssClass : 'textSection--proof',
                   cssClass: 'aspect--model',
                   initialR: pointRadius,
                   letterAngle : 0,
@@ -215,7 +215,7 @@
                   doPaintPname:false,
             },
             P : {
-                  cssClass: 'theorion--proof',
+                  cssClass: 'textSection--proof',
                   pcolor: pt.static,
                   initialR: pointRadius,
                   letterAngle : 0,
@@ -477,14 +477,14 @@
             {
                 'PC' :
                 {
-                    cssClass: 'theorion--proof',
+                    cssClass: 'textSection--proof',
                     pcolor : pt[ "static" ],
                 },
             },
             {
                 'PB' :
                 {
-                    cssClass: 'theorion--proof',
+                    cssClass: 'textSection--proof',
                     pcolor : pt[ "static" ],
                 },
             },

--- a/contents/b1sec5lemma21/txt/english.txt
+++ b/contents/b1sec5lemma21/txt/english.txt
@@ -68,7 +68,7 @@ Page 487.
 
 And conversely, if the movable point ¦D¦¦ lies in a conic passing through the given points B, C, and ¦A¦¦; and if angle DBM is always equal to the given angle ABC, and the angle DCM is always equal to the given angle ACB; and if, when point ¦D¦¦ falls successively on any two stationary points p and P of the conic, the movable point M falls successively on the two stationary points n and N; then through these same points n and N draw the straight line nN, and this will be the perpetual locus of the movable point M. For, if it can be done, let point M move in some curved line. Then the point ¦D¦¦ will lie in a conic passing through the five points B, C, ¦A¦¦, p, and P when the point M perpetually lies in a curved line. But from what has already been demonstrated, point ¦D¦¦ will also lie in a conic passing through the same five points B, C, ¦A¦¦, p, and P when point M perpetually lies in a straight line. Therefore, two conies will pass through the same five points, contrary to
  
-<a target="_blank" href="?conf=sappId=b1sec5lemma20,theorionId=corollary,aspectId=english,subessayId=corollary3">
+<a target="_blank" href="?conf=sappId=b1sec5lemma20,textSectionId=corollary,aspectId=english,subessayId=corollary3">
 lem. 20, corol. 3.</a>
 
 Therefore, it is absurd to suppose the point M to be moving in a curved line. Q.E.D. 

--- a/contents/b1sec8prop41/js/amode8captures.js
+++ b/contents/b1sec8prop41/js/amode8captures.js
@@ -49,7 +49,7 @@
     ///"init model parameters"
     function amode2rgstate( captured )
     {
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
 
         //------------------------------------------------
         // //\\ returns diagram back at every menu click

--- a/contents/b1sec8prop41/js/completes-sliders-creation.js
+++ b/contents/b1sec8prop41/js/completes-sliders-creation.js
@@ -118,7 +118,7 @@
         // //\\ instant point's "r"
         //=========================================================================
         rg.D.acceptPos = ( newPos, dragMove ) => {
-            var { theorion, aspect, subessay } = amode;
+            var { textSection, aspect, subessay } = amode;
             //var stash = [ newPos[0], newPos[1] ];
             var inc = pointEisIncluded( newPos[1] );
             inc = inc && newPos[1] < rg.V.pos[1];
@@ -149,7 +149,7 @@
         };
 
         rg.v.acceptPos = ( newPos, dragMove ) => {
-            var { theorion, aspect, subessay } = amode;
+            var { textSection, aspect, subessay } = amode;
             var newPos0  = dragMove[0] + sData.vbpos[0];
             var newPos1  = -dragMove[1] + sData.vbpos[1];
             //-------------------------------------------------------------------

--- a/contents/b1sec8prop41/js/main-legend.js
+++ b/contents/b1sec8prop41/js/main-legend.js
@@ -28,12 +28,12 @@
         return;
         //see lemma 11 for the sample
         /*
-        create_digital_legend_for_theorion( 'proof' );
-        create_digital_legend_for_theorion( 'corollary' );
+        create_digital_legend_for_textSection( 'proof' );
+        create_digital_legend_for_textSection( 'corollary' );
         */
     }
 
-    function create_digital_legend_for_theorion( theorion )
+    function create_digital_legend_for_textSection( textSection )
     {
         //--------------------------
         // //\\ data source scenario
@@ -90,11 +90,11 @@
         // \\// data source scenario
         //--------------------------
 
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             tableCaption    : 'Areas and Ratios',
             noTableTitle    : false,
             stdMod_given    : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             //makesCaptionCluster, //optional
@@ -163,7 +163,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b3lemma5/js/main-legend.js
+++ b/contents/b3lemma5/js/main-legend.js
@@ -24,14 +24,14 @@
 
     function create_digital_legend()
     {
-        var theorion        = 'proof';
+        var textSection        = 'proof';
         var columnPars      = sconf.basePairs;
         var rowsCount       = columnPars.length-1;
         var clustersCount   = columnPars.length-1;
         var tableCaption    = 'Divided Differences';
-        ssF.createTheorionLegend({
+        ssF.createtextSectionLegend({
             stdMod_given : stdMod,
-            theorion,
+            textSection,
             rowsCount,
             clustersCount,
             tableCaption,
@@ -170,7 +170,7 @@
         }
     }
     //=========================================
-    // \\// creates theorion table
+    // \\// creates textSection table
     //=========================================
 
 }) ();

--- a/contents/b3lemma5/js/media-upcreate.js
+++ b/contents/b3lemma5/js/media-upcreate.js
@@ -51,7 +51,7 @@
               .html( "function" )
               ;
         }
-        var tlegend = ns.haz( rg[ 'main-legend' ], amode.theorion );
+        var tlegend = ns.haz( rg[ 'main-legend' ], amode.textSection );
         if( tlegend ) {
             ///above lines do create legend for all theoreons, this line
             ///shows only for one:

--- a/contents/conf/conf.js
+++ b/contents/conf/conf.js
@@ -37,7 +37,7 @@
         doDisplayPageTopNavigatMenu : true,
         lemmaHasHomeButton          : true,
         homeButtonName              : 'Contents',
-        theorionTab_nonClickable    : false,
+        textSectionTab_nonClickable    : false,
 
         //:data
         svgNS : ns.svgNS,

--- a/contents/lemma2-12-handles/js/core/gui-update.js
+++ b/contents/lemma2-12-handles/js/core/gui-update.js
@@ -426,7 +426,7 @@
         //--------------------------------------
         {
             let l2 = fconf.sappId.indexOf('lemma2') === 0;
-            let checked = amode.theorion !== 'claim';
+            let checked = amode.textSection !== 'claim';
             rg.F.undisplay = !checked || videoMode || onlyFig || l2;
             rg.f.undisplay = !checked || videoMode || onlyFig || l2;
             rg.AF.undisplay = !checked;

--- a/contents/lemma2-mono-stashed-program/js/core/gui-update.js
+++ b/contents/lemma2-mono-stashed-program/js/core/gui-update.js
@@ -426,7 +426,7 @@
         //--------------------------------------
         {
             let l2 = fconf.sappId.indexOf('lemma2') === 0;
-            let checked = amode.theorion !== 'claim';
+            let checked = amode.textSection !== 'claim';
             rg.F.undisplay = !checked || videoMode || onlyFig || l2;
             rg.f.undisplay = !checked || videoMode || onlyFig || l2;
             rg.AF.undisplay = !checked;

--- a/contents/lemma2-non-monotonic/js/core/gui-update.js
+++ b/contents/lemma2-non-monotonic/js/core/gui-update.js
@@ -446,7 +446,7 @@
         //--------------------------------------
         {
             let l2 = fconf.sappId.indexOf('lemma2') === 0;
-            let checked = amode.theorion !== 'claim';
+            let checked = amode.textSection !== 'claim';
             rg.F.undisplay = !checked || videoMode || onlyFig || l2;
             rg.f.undisplay = !checked || videoMode || onlyFig || l2;
             rg.AF.undisplay = !checked;

--- a/contents/lemma2/js/gui-update.js
+++ b/contents/lemma2/js/gui-update.js
@@ -438,7 +438,7 @@
         //--------------------------------------
         {
             let l2 = fconf.sappId.indexOf('lemma2') === 0;
-            let checked = amode.theorion !== 'claim';
+            let checked = amode.textSection !== 'claim';
             let undisplay = !checked || videoMode || onlyFig;
             rg.F.undisplay = undisplay||l2;
             rg.f.undisplay = undisplay||l2;

--- a/doc/README.txt
+++ b/doc/README.txt
@@ -56,13 +56,13 @@ rgtools - possibly relates for batton "lab" for some model options, choice of fu
           thickness of lines, capture model states;
 rg - stands for registry, often used for geometrical object: dots, lines, ...
 
-amode - keeps current model state: var { theorion, aspect, submodel, subessay } = amode;
+amode - keeps current model state: var { textSection, aspect, submodel, subessay } = amode;
 
-theorion usually takes values as strings "proof", "clame", "corollary", so has semantics of fragment of logical text,
+textSection usually takes values as strings "proof", "clame", "corollary", so has semantics of fragment of logical text,
 
-aspect usually takes values as "english", "latin", "exercise", 'comment" - is a languge or cosmetic  form of own theorion,
+aspect usually takes values as "english", "latin", "exercise", 'comment" - is a languge or cosmetic  form of own textSection,
 
-Precisely strings "proof", "claim", ... "latin", "english" are assigned to theorion_id and aspect_id
+Precisely strings "proof", "claim", ... "latin", "english" are assigned to textSection_id and aspect_id
 correcspondingly in code. These string are keys in Book-text segments in form:
 *::*claim|english
 ...
@@ -73,8 +73,8 @@ exegs - array of compiled essays of lemma
 //==============================================
 // //\\ sapwns script-embedded-in-text to html
 //==============================================
-eachprop( exegs, ( theorionAspects, theorion_id ) => {
-    eachprop( theorionAspects, ( exAspect, aspect_id ) => {
+eachprop( exegs, ( textSectionAspects, textSection_id ) => {
+    eachprop( textSectionAspects, ( exAspect, aspect_id ) => {
         exAspect.subexegs.forEach( ( subexeg, exegId ) => {
 
 
@@ -104,7 +104,7 @@ aspect-menu submenu: subessays - vertical
 
 ********************************************
 menu-dom-structure
-    fapp.fappRoot$.addClass( 'theorion--' + amode.theorion + ' aspect--' + amode.aspect );
+    fapp.fappRoot$.addClass( 'textSection--' + amode.textSection + ' aspect--' + amode.aspect );
         sDomN.essaionsRoot$ = $$.div().cls( bsl-text-widget leftside-menuholder )
             leftSide_menuRotator$ = $$.dct( 'left-side-menu-rotator', ||| made in build_menu_top_leafs_placeholders()
                 sDomN.teafs$[ mcat_id ] = $$.dct( 'menu-teaf ' + mcat_id, ||| build_menu_top_leafs_placeholders()

--- a/src/base/app-tree.js
+++ b/src/base/app-tree.js
@@ -71,7 +71,7 @@
     function setsEngineDefaults()
     {
         //these are pre-professorscripts values: at engine level
-        amode.theorion = '';
+        amode.textSection = '';
         amode.aspect = '';
         amode.subessay = '';
         //todm: poor? name: to be "amode.stdmod" //study model

--- a/src/base/css/dispatch-css.js
+++ b/src/base/css/dispatch-css.js
@@ -53,12 +53,12 @@
 
     /* text area horizontal and vertical tab buttons */
     function createsMenuCss( cssp, fconf ) {
-        var theorionChildWidth = (100 / sDomN.theorionMenuMembersCount).toFixed();
+        var textSectionChildWidth = (100 / sDomN.textSectionMenuMembersCount).toFixed();
         var aspectionChildWidth = (100 / sDomN.aspectionMenuMembersCount).toFixed();
         var leftTopLeafLength =
             ( sDomN.aspectionMenuMembersCount * fconf.LEFT_SIDE_MENU_ITEM_LENGTH ).toFixed();
 
-        root.style.setProperty('--theorionChildWidth', theorionChildWidth);
+        root.style.setProperty('--textSectionChildWidth', textSectionChildWidth);
         root.style.setProperty('--aspectionChildWidth', aspectionChildWidth);
         root.style.setProperty('--leftTopLeafLength', leftTopLeafLength);
 
@@ -67,14 +67,14 @@
         //===========================
         // //\\ setting up shuttle CSS for all possible menu leaf choices
         var ret;
-        for( var ix=0; ix<sDomN.theorionMenuMembersCount; ix++ ) {
+        for( var ix=0; ix<sDomN.textSectionMenuMembersCount; ix++ ) {
             ret += `
-                .menu-teaf.theorion .decorated.litem-${ix},
-                .menu-teaf.theorion .litem-${ix},
-                .menu-teaf.theorion .shuttle-${ix} {
-                    left       :${theorionChildWidth*ix}%;
+                .menu-teaf.textSection .decorated.litem-${ix},
+                .menu-teaf.textSection .litem-${ix},
+                .menu-teaf.textSection .shuttle-${ix} {
+                    left       :${textSectionChildWidth*ix}%;
                 }
-                .menu-teaf.theorion .shuttle-${ix} {
+                .menu-teaf.textSection .shuttle-${ix} {
                     transition :top 0.3s ease-in-out, left 0.5s ease-in-out;
                 }
             `;

--- a/src/base/css/lemma-comp.css
+++ b/src/base/css/lemma-comp.css
@@ -372,7 +372,7 @@ div.leftside-menuholder div.original-text.chosen {
 /* top-level geometrical sub-containers    */
 /*******************************************/
 /* geometrically contains all button-shapes and decorations */
-/* theorion and aspection */
+/* textSection and aspection */
 .menu-teaf {
     position        :relative;
     display         :inline-block;
@@ -400,8 +400,8 @@ div.leftside-menuholder div.original-text.chosen {
     width       : calc(var(--leftTopLeafLength) * 1px);
 }
 
-/* theorion */
-.menu-teaf.theorion {
+/* textSection */
+.menu-teaf.textSection {
     width       : calc(100% - var(--LEFT_SIDE_MENU_WIDTH));
 }
 
@@ -425,8 +425,8 @@ div.leftside-menuholder div.original-text.chosen {
     z-index         :30;
 }
 
-.menu-teaf.theorion .litem {
-    width           :calc(var(--theorionChildWidth) * 1%);
+.menu-teaf.textSection .litem {
+    width           :calc(var(--textSectionChildWidth) * 1%);
 }
 
 .menu-teaf.aspect .litem {

--- a/src/base/css/pages/model.css
+++ b/src/base/css/pages/model.css
@@ -77,9 +77,9 @@ svg text {
 }
 
 #lemma2.bsl-approot #widest-visib-toggler-wrap,
-.bsl-approot.theorion--claim #widest-visib-toggler-wrap,
+.bsl-approot.textSection--claim #widest-visib-toggler-wrap,
 .widest-rectangular.invisible,
-.bsl-approot.theorion--claim .widest-rectangular {
+.bsl-approot.textSection--claim .widest-rectangular {
     display:none;
 }
   

--- a/src/base/css/roots.css
+++ b/src/base/css/roots.css
@@ -33,7 +33,7 @@
     --doDisplayPageTopNavigatMenu : flex; 
     --LEFT_SIDE_MENU_WIDTH : 40px; /* from contents\conf\conf.js */
     --LEFT_SIDE_MENU_OFFSET_X: 20px;
-    --theorionChildWidth : 1;
+    --textSectionChildWidth : 1;
     --aspectionChildWidth : 1;
     --leftTopLeafLength : 1;
 }

--- a/src/base/css/subroots.css
+++ b/src/base/css/subroots.css
@@ -175,18 +175,18 @@ sup {
 }
 
 /*todm: should be automated */
-.theorion--claim .main-legend.proof,
-.theorion--corollary .main-legend.proof {
+.textSection--claim .main-legend.proof,
+.textSection--corollary .main-legend.proof {
     display:none;
 }
 /* visibility per model-mode */
-.theorion--corollary .main-legend.claim,
-.theorion--proof .main-legend.claim {
+.textSection--corollary .main-legend.claim,
+.textSection--proof .main-legend.claim {
     display:none;
 }
 /* visibility per model-mode */
-.theorion--claim .main-legend.corollary,
-.theorion--proof .main-legend.corollary {
+.textSection--claim .main-legend.corollary,
+.textSection--proof .main-legend.corollary {
     display:none;
 }
 

--- a/src/base/dom/create/lemma-master-menu-lib.js
+++ b/src/base/dom/create/lemma-master-menu-lib.js
@@ -7,7 +7,7 @@
         sDomF, sDomN,
     } = window.b$l.apptree({
     });
-    sDomF.makes_theorionTab_nonClickable = makes_theorionTab_nonClickable;
+    sDomF.makes_textSectionTab_nonClickable = makes_textSectionTab_nonClickable;
     return;
 
 
@@ -21,15 +21,15 @@
     ///tabIsInactive flag; this site is such a site;
     ///this function does this job for this site;
     ///todm: non-elegant solution: too much coding:
-    function makes_theorionTab_nonClickable()
+    function makes_textSectionTab_nonClickable()
     {
-        sDomN.teafs$.theorion.addClass( 'non-clickable' )
+        sDomN.teafs$.textSection.addClass( 'non-clickable' )
             .e( 'click', function( event ) {
                 event.stopPropagation = true;
             })
             ;
 
-        sDomN.teafs$.theorion.tabIsInactive = true;
+        sDomN.teafs$.textSection.tabIsInactive = true;
         globalCss.update( `
                 .leftside-menuholder .menu-teaf.non-clickable
                 .litem:hover {

--- a/src/base/dom/create/lemma-master-menu.js
+++ b/src/base/dom/create/lemma-master-menu.js
@@ -1,8 +1,8 @@
 /*
         vital jargon:
-            mcat_id = "theorion", "aspect"
+            mcat_id = "textSection", "aspect"
             menu tree is like:
-                mcat_id = "theorion"
+                mcat_id = "textSection"
                               scat_id = claim, proof, ...           
                 mcat_id = "aspect"
                               scat_id = latin, english, video, ...           
@@ -53,8 +53,8 @@
             build_teaf__localfun( mcat_id, subcatsMenu,
             );
         });
-        //:sets up a state and theorion-menu
-        var submItem = sconf.asp8theor_menus.theorion.duplicates[ amode.theorion ];
+        //:sets up a state and textSection-menu
+        var submItem = sconf.asp8theor_menus.textSection.duplicates[ amode.textSection ];
         do_select_leaf__localfun( submItem.leafRk, !'amodel2app_8_extraWork' );
 
         //:sets up aspect menu
@@ -82,7 +82,7 @@
             );
         }
 
-        ['aspect','theorion'].forEach( function( mcat_id ) {
+        ['aspect','textSection'].forEach( function( mcat_id ) {
             sDomN.teafs$[ mcat_id ] = $$.dct(
                 'menu-teaf ' + mcat_id,
                 fconf.attach_menu_to_essaion_root ?
@@ -91,8 +91,8 @@
             );
         });
 
-        if( haz( fconf, 'theorionTab_nonClickable' ) ){
-            sDomF.makes_theorionTab_nonClickable();
+        if( haz( fconf, 'textSectionTab_nonClickable' ) ){
+            sDomF.makes_textSectionTab_nonClickable();
         }
     }
 
@@ -150,8 +150,8 @@
     /// makes tab's components button;
     function make_menu_leaf__onceLocFun( leafRk )
     {
-        var scat_id     = leafRk.scat_id;   //sub category: theorion or aspect
-        var mcat_id     = leafRk.mcat_id;   //main category: theorion or aspect
+        var scat_id     = leafRk.scat_id;   //sub category: textSection or aspect
+        var mcat_id     = leafRk.mcat_id;   //main category: textSection or aspect
         var mitemIx     = leafRk.ix;
         var caption     = leafRk.caption;
         var studylab    = leafRk.studylab;
@@ -162,9 +162,9 @@
         // //\\ fluid-html part
         // //\\ video-button placeholder
         //------------------------------
-        //if( mcat_id === 'theorion' ) {
+        //if( mcat_id === 'textSection' ) {
         ///this thing participate in creation placeholder inside
-        ///theorion tab-tags-buttons
+        ///textSection tab-tags-buttons
         var iconClass = 'videoicon-placeholder' +
             ( mcat_id === 'aspect' ? '-aspect' : '' );
         var videoPlaceholder$ = toreg( iconClass )( scat_id,
@@ -194,7 +194,7 @@
             .e('mouseover', ()=>{ decor$.addClass( 'hovered' ) })
             .e('mouseleave', ()=>{ decor$.removeClass( 'hovered' ) })
             .e('click', function( event ) {
-                if( mcat_id !== 'theorion' || !fconf.theorionTab_nonClickable ) {
+                if( mcat_id !== 'textSection' || !fconf.textSectionTab_nonClickable ) {
 
                     //:todm: it is not clear why this is required, and why flag
                     //:'chosen' is not cleared up downstream automatically
@@ -240,7 +240,7 @@
         var scat_id         = leafRk.scat_id;
         var mcat_id         = leafRk.mcat_id;
         var decorOfShuttle$ = leafRk.decorOfShuttle$;
-        var exAspect        = exegs[ amode.theorion ][ amode.aspect ];
+        var exAspect        = exegs[ amode.textSection ][ amode.aspect ];
 
         //todm: with this lemma 2 looks bad ... why? ... missed resize?
         //if( amode[ mcat_id ] === scat_id ) return; //click is idempotent
@@ -252,7 +252,7 @@
         leafRk.li$.removeClass( 'chosen' );
 
         //sets fappRoot flags
-        fapp.fappRoot$.removeClass( 'theorion--' + amode.theorion +
+        fapp.fappRoot$.removeClass( 'textSection--' + amode.textSection +
             ' aspect--' + amode.aspect );
         //sets content-text visibility
         if( userOptions.shouldShowSubessayMenu(exAspect) ) {
@@ -274,7 +274,7 @@
         //**************************************************************
         //**************************************************************
         amode[ mcat_id ]    = scat_id;
-        var exAspect        = exegs[ amode.theorion ][ amode.aspect ];
+        var exAspect        = exegs[ amode.textSection ][ amode.aspect ];
         //if no default, always selects only the first essay
         var subexeg0        = exAspect.subexegs[ 0 ];
         var subexeg         = ns.haz( exAspect, "default" ) || subexeg0;
@@ -293,7 +293,7 @@
         //==================================================
         //flag to root
         fapp.fappRoot$.addClass(
-            'theorion--' + amode.theorion + ' aspect--' + amode.aspect
+            'textSection--' + amode.textSection + ' aspect--' + amode.aspect
         );
 
         //flag to content-text-components
@@ -316,9 +316,9 @@
         leafRk.li$.addClass( 'chosen' ); //todm redundant state-flag, but fails if omitted
         //flag to shuttle
         decorOfShuttle$.a('class','litem shuttle shuttle-'+leafRk.ix);
-        if( mcat_id === 'theorion' ) {
-            ns.eachprop( exegs[ amode.theorion ], ( exegAsp, aspId ) => {
-                //updates left menu caption for theorions with omitted aspect texts
+        if( mcat_id === 'textSection' ) {
+            ns.eachprop( exegs[ amode.textSection ], ( exegAsp, aspId ) => {
+                //updates left menu caption for textSections with omitted aspect texts
                 var menItem = sconf.asp8theor_menus.aspect.duplicates[ aspId ];
                 menItem.leafRk.mItemCaptionHtml$.html(
                     exegAsp.subexegs[ 0 ].essayHeader.menuCaption ||
@@ -417,7 +417,7 @@
         ////real human acted on app,
         ////because of this, human activity state-machines are being
         ////informed in this block,
-        eachprop( exegs[ amode.theorion ][ amode.aspect ].subessay2subexeg,
+        eachprop( exegs[ amode.textSection ][ amode.aspect ].subessay2subexeg,
                   (subessayRack, sname) => {
 
             ///this is flag of presense of activity-script for this subessay
@@ -432,7 +432,7 @@
         });
 
         var subessayRack =
-            exegs[ amode.theorion ][ amode.aspect ].subessay2subexeg[ amode.subessay ];
+            exegs[ amode.textSection ][ amode.aspect ].subessay2subexeg[ amode.subessay ];
         if( haz( subessayRack, 'stateId2state' ) ) {
             ////adds state "start" to avoid entering the state machine in ambiguous state
             ////in plain words, every "user click" is "start over"

--- a/src/base/dom/create/populates-media-super-root.js
+++ b/src/base/dom/create/populates-media-super-root.js
@@ -298,7 +298,7 @@
         // //\\ study image and s ubmodel
         //..............................
         var images = {};
-        //top mode CSS: bsl-approot theorion--claim aspect--video
+        //top mode CSS: bsl-approot textSection--claim aspect--video
         var imgCss = 'bsl-bg-image';
 
         // //\\ hides all media before visualizing in relevant egreg-GUI
@@ -344,7 +344,7 @@
                     //      the first css is for image,
                     //      the second is for svg,
                     //***************************************************************
-                    var ww = `.${cssp}-approot.theorion--${tkey}.aspect--${akey}`;
+                    var ww = `.${cssp}-approot.textSection--${tkey}.aspect--${akey}`;
                     css += `
                         ${ww} .${cssId} {
                             display :inline;

--- a/src/base/dom/secondary/video-help-manager.js
+++ b/src/base/dom/secondary/video-help-manager.js
@@ -59,7 +59,7 @@
             sDomN.videoListPopup_button_onModelPane$.css(
                 'display','none');
 
-            //:theorion menu cleanup
+            //:textSection menu cleanup
             ///cleans up video icon placeholders in exegesis-tabs,
             ///in tabs, not in help button,
             [ 'videoicon-placeholder', 'videoicon-placeholder-aspect' ]
@@ -69,7 +69,7 @@
                         iconRg$.html('');
                     });
                 });
-            var vConf = exegs[ amode['theorion'] ][ amode['aspect'] ].subexegs[0]
+            var vConf = exegs[ amode['textSection'] ][ amode['aspect'] ].subexegs[0]
                         .essayHeader.video;
             if( vConf ) {
                 if( vConf['to model help'] ) {
@@ -96,7 +96,7 @@
                     //----------------------------------------------------------
                     let iconClass = 'videoicon-placeholder' +
                                     ( has( vConf, 'to-aspect' ) ? '-aspect' : '' );
-                    let category = has( vConf, 'to-aspect' ) ? 'aspect' : 'theorion';
+                    let category = has( vConf, 'to-aspect' ) ? 'aspect' : 'textSection';
                     var itemDom$ = createVideoIconEntry( vConf );
                     var dom_already_built = rg[ iconClass ][ amode[ category ] ];
                     if( dom_already_built  ) {

--- a/src/base/lemma/init-sapp.js
+++ b/src/base/lemma/init-sapp.js
@@ -108,7 +108,7 @@
         //=======================================================
         // //\\ executes "lesson-guide-scenario" from start-event
         //=======================================================
-        eachprop( exegs[ amode.theorion ][ amode.aspect ].subessay2subexeg,
+        eachprop( exegs[ amode.textSection ][ amode.aspect ].subessay2subexeg,
                     (subessayRack, sname) => {
             if( haz( subessayRack, 'stateId2state' ) ) {
                 subessayRack.scenario_stateId = 'start';

--- a/src/base/lemma/media-model/linears.js
+++ b/src/base/lemma/media-model/linears.js
@@ -414,7 +414,7 @@
     //==========================================
     ///Input:   triang = rg[ triangleId ]
     ///         triang.vertices
-    ///         cssCls can be for 'theorion--proof'
+    ///         cssCls can be for 'textSection--proof'
     function paintTriangle( triangleId, cssCls, tpclass, defaultFill, )
     {
         var triang = rg[ triangleId ];

--- a/src/base/lemma/media-model/main-legend.js
+++ b/src/base/lemma/media-model/main-legend.js
@@ -14,7 +14,7 @@
     } = window.b$l.apptree({
         ssFExportList :
         {
-            createTheorionLegend,
+            createtextSectionLegend,
         },
     });
     return;
@@ -28,12 +28,12 @@
 
 
     //=========================================
-    // //\\ creates theorion table
+    // //\\ creates textSection table
     //      does one time work of html creation
     //=========================================
-    function createTheorionLegend({
+    function createtextSectionLegend({
         stdMod_given,
-        theorion,
+        textSection,
         rowsCount,
         clustersCount,
         tableCaption,
@@ -48,11 +48,11 @@
     }){
         //stdMod_given.upcreate_mainLegend  = upcreate_mainLegend;
         toreg( 'main-legend' )
-            ( theorion,     {
+            ( textSection,     {
                                 upcreate_mainLegend,
                             }
             );
-        var rgTeoTab = rg[ 'main-legend' ][ theorion ];
+        var rgTeoTab = rg[ 'main-legend' ][ textSection ];
         var clustersToUpdate = [];
         var tableCaption$;
         var tb;
@@ -67,7 +67,7 @@
 
         createsTablePlaceholder();
         createsIdleFirstRow_forFormat = createsIdleFirstRow_forFormat || createsIdleFirstRow_forFormat_default;
-        createsIdleFirstRow_forFormat( tb, theorion );
+        createsIdleFirstRow_forFormat( tb, textSection );
         !noTableTitle && createsTableTitle();
         creates_caption8body_rows();
         visibilizeTable();
@@ -88,9 +88,9 @@
             tb = $$
                 .c('table')
                 .to( stdMod.legendRoot$ )
-                .cls( 'main-legend ' + theorion )
+                .cls( 'main-legend ' + textSection )
 
-                //removes set of .main-legend.]theorion[ {
+                //removes set of .main-legend.]textSection[ {
                 .css( 'border-collapse', 'collapse' )
                 ()
                 //css( 'table-layout', 'auto' ) //makes problem ... table moves out of pane ...
@@ -116,7 +116,7 @@
         ///=====================
         /// first row for format
         ///=====================
-        function createsIdleFirstRow_forFormat_default( tb, theorion )
+        function createsIdleFirstRow_forFormat_default( tb, textSection )
         {
             //=====================================================
             // //\\ idle first row to format table for fixed-layout
@@ -124,7 +124,7 @@
             var row = $$.c('tr')
                 //vital ... removes global css which corrupts table
                 //aka .addClass( 'proof row1 tostroke' )
-                .addClass( theorion +' tostroke')
+                .addClass( textSection +' tostroke')
 
                 .css( 'visibility', 'hidden' ) //todm ... tmp fix
                 .to(tb)

--- a/src/base/lemma/media-model/media-upcreate.js
+++ b/src/base/lemma/media-model/media-upcreate.js
@@ -47,7 +47,7 @@
         haff( stdMod, 'media_upcreate___before_basic' );
 
         //:updates subessay menu
-        var exAspect = exegs[ amode.theorion ][ amode.aspect ];
+        var exAspect = exegs[ amode.textSection ][ amode.aspect ];
         var subexeg = exAspect.subessay2subexeg[ amode.subessay ];
         sDomF.addsChosenCSSCls_to_subessay8menuSubitem({ exAspect, subexeg })
 
@@ -147,7 +147,7 @@
         // may have create_digital_legend
         //ini ssF, so thet skip this block
         if( ns.h( stdMod, 'create_digital_legend' ) ) {
-            var tlegend = ns.haz( rg[ 'main-legend' ], amode.theorion );
+            var tlegend = ns.haz( rg[ 'main-legend' ], amode.textSection );
             if( ns.h( stdMod, 'upcreate_mainLegend' ) ){
                 ///above lines do create legend for all theoreons, this line
                 ///shows only for one:

--- a/src/base/lemma/study-model/subessay-amode-2-lemma.js
+++ b/src/base/lemma/study-model/subessay-amode-2-lemma.js
@@ -35,7 +35,7 @@
         if( amodel2app_8_extraWork ) {
             doMinimizeTextMenus();
         }
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         //------------------------------------------------
         // //\\ sets "undefined" flag
         //      for registry rg members with defined pname,
@@ -70,12 +70,12 @@
         /// //\\ takes conditions scripted at the bottom of professor-script,
         ///      loops via these conditions and executes them,
         ///         context is a closure of running function:
-        ///             { theorion, aspect, subessay ...
+        ///             { textSection, aspect, subessay ...
         ///
         ///      "__amode2rgstate" can come from JS-module
         ///------------------------------------------------------------------
         ssD.__amode2rgstate.forEach( (cblock,ix) => {
-            ///aka: "true", or "( theorion === 'claim' || ...
+            ///aka: "true", or "( textSection === 'claim' || ...
             var cond = cblock[0];
             if( eval( cond ) ) {
                 var instr = cblock[ 1 ];
@@ -157,7 +157,7 @@
             if( overrideAspect ) {
                 var hideAspect = !fconf.showAspectMenu;
             } else if( hideSingles ) {
-                var hideAspect = Object.keys( exegs[ amode.theorion ] ).length === 1;
+                var hideAspect = Object.keys( exegs[ amode.textSection ] ).length === 1;
             }
 
             var textMenuStyle$ = haz( sDomN, 'textMenuStyle$' );
@@ -167,7 +167,7 @@
             var html = '';
             if( hideTheor ){
                 html += `
-                    .leftside-menuholder .menu-teaf.theorion {
+                    .leftside-menuholder .menu-teaf.textSection {
                         display : none;
                     }
                 `;

--- a/src/base/parser/FR-I-indexed-links8topics.js
+++ b/src/base/parser/FR-I-indexed-links8topics.js
@@ -31,8 +31,8 @@
     */
     function exegs__2__dom_indexedLinks_indexedTopics()
     {
-        eachprop( exegs, ( theorionAspects, mcat_id ) => {
-            eachprop( theorionAspects, ( exAspect, scat_id ) => {
+        eachprop( exegs, ( textSectionAspects, mcat_id ) => {
+            eachprop( textSectionAspects, ( exAspect, scat_id ) => {
                 exAspect.subexegs.forEach( ( subexeg, exegId ) => {
                     subexeg.cssCls = ' subessay-menuitem-id-' + exegId;
                     //====================================================

--- a/src/base/parser/FR-II-III-dom8css8mjax.js
+++ b/src/base/parser/FR-II-III-dom8css8mjax.js
@@ -24,8 +24,8 @@
         if( sconf.dontDoMathJax ) {
            // delete window.MathJax;
         }
-        eachprop( exegs, ( theorionAspects, mcat_id ) => {
-            eachprop( theorionAspects, ( exAspect, scat_id ) => {
+        eachprop( exegs, ( textSectionAspects, mcat_id ) => {
+            eachprop( textSectionAspects, ( exAspect, scat_id ) => {
                 exAspect.subexegs.forEach( ( subexeg ) => {
                     subexeg.built_act8stat_fragments_texts = [];
 

--- a/src/base/parser/LANDING-V-content2subexegs.js
+++ b/src/base/parser/LANDING-V-content2subexegs.js
@@ -124,7 +124,7 @@
                 //             precontent = \nJSON*..*\n content
                 //             JSON in singleSubessay is optional
                 //
-                //      below: ess_instructions[1] = theorion_id: claim, proof,
+                //      below: ess_instructions[1] = textSection_id: claim, proof,
                 //                                            theorems, neutral, ...
                 //             ess_instructions[2] = aspect_id: english,... latin, ...
                 //             ess_instructions[3] = precontent
@@ -135,7 +135,7 @@
 
                 //ess_instructions[3] is text itself
                 if( ess_instructions && ess_instructions[3] ) {
-                    var theorion_id = ess_instructions[1];
+                    var textSection_id = ess_instructions[1];
                     var aspect_id   = ess_instructions[2];
                     var precontent  = ess_instructions[3];
 
@@ -158,8 +158,8 @@
                     //===============================================================
                     // //\\ sets initial amode
                     //===============================================================
-                    sn( theorion_id, exegs );
-                    var aspExeg     = sn( aspect_id, exegs[ theorion_id ] );
+                    sn( textSection_id, exegs );
+                    var aspExeg     = sn( aspect_id, exegs[ textSection_id ] );
 
                     //group of "objectivied"-subessays === group of subexegs,
                     //subexeg is to be further structured,
@@ -186,20 +186,20 @@
                             var ami = sn( 'amodel_initial', sapp, {
                                 posOverriden : false
                             });
-                            var theorionId  = haz( fconf, 'theorionId' );
+                            var textSectionId  = haz( fconf, 'textSectionId' );
                             var aspectId    = haz( fconf, 'aspectId' );
-                            if( theorionId && aspectId ) {
+                            if( textSectionId && aspectId ) {
                                 var subessayId  = haz( fconf, 'subessayId' );
                                 if( !subessayId ) {
                                     ////default subessayId is set to 0,
                                     ////to enable missed subessayId in URL-query-config
                                     subessayId = '0';
                                 }
-                                ami.theorion = theorionId;
+                                ami.textSection = textSectionId;
                                 ami.aspect = aspectId;
                                 ami.subessay = subessayId;
                                 ami.posOverriden = {
-                                    theorion : theorionId,
+                                    textSection : textSectionId,
                                     aspect : aspectId,
                                     subessay : subessayId,
                                 };
@@ -207,7 +207,7 @@
                         }
 
                         if( !ami.posOverriden ) {
-                            ami.theorion = theorion_id;
+                            ami.textSection = textSection_id;
                             ami.aspect = aspect_id;
                             ami.subessay = essayHeader.subessay;
                             //sets 'default' for case it will be missed in all text
@@ -224,7 +224,7 @@
                         ///these conditions preserve legacy structure of
                         ///essayHeader in case if default are supplied from URLquery
                         if(
-                            theorion_id          !== ao.theorion ||
+                            textSection_id          !== ao.textSection ||
                             aspect_id            !== ao.aspect ||
                             essayHeader.subessay !== ao.subessay
                         ){
@@ -353,7 +353,7 @@
             //===========================================================
             sconf.asp8theor_menus = {};
 
-            eachprop( exegs, ( exAspects, theorion_id ) => {
+            eachprop( exegs, ( exAspects, textSection_id ) => {
                 eachprop( exAspects, ( exAspect, aspect_id ) => {
                     exAspect.subexegs.forEach( ( subex, subexId ) => {
                         var essayHeader = subex.essayHeader;
@@ -362,8 +362,8 @@
                         ///we need menu and classes only once per theor-aspect pair
                         if( subexId === 0 ) {
 
-                            //.not elegant: should be in "theorion" loop, not in child loop,
-                            setMenu( theorion_id, 'theorion', essayHeader );
+                            //.not elegant: should be in "textSection" loop, not in child loop,
+                            setMenu( textSection_id, 'textSection', essayHeader );
 
                             setMenu( aspect_id, 'aspect', essayHeader );
                             //******************************************************************
@@ -402,7 +402,7 @@
                         if( haz( essayHeader, "default" ) === '1' ){
                             //this is an alternative "if" which must work too
                             //if(
-                            //    sapp.amodel_initial.theorion === theorion_id &&
+                            //    sapp.amodel_initial.textSection === textSection_id &&
                             //    sapp.amodel_initial.aspect === aspect_id
                             //){
                             //todm ... name "default" is very unlucky, do change it ...
@@ -443,7 +443,7 @@
                     /*
                     asp8theor_menus :
                     {
-                        theorion: {
+                        textSection: {
                             list:
                             [
                                 { id:'claim' },
@@ -476,9 +476,9 @@
                     var menuItem = { id:leafId };
                     men.duplicates[ leafId ] = menuItem;
                     men.list.push( menuItem );
-                    if( mcat_id === 'theorion' ) {
-                        sDomN.theorionMenuMembersCount =
-                            ( sDomN.theorionMenuMembersCount || 0 ) + 1;
+                    if( mcat_id === 'textSection' ) {
+                        sDomN.textSectionMenuMembersCount =
+                            ( sDomN.textSectionMenuMembersCount || 0 ) + 1;
                     } else if( mcat_id === 'aspect' ) {
                         sDomN.aspectionMenuMembersCount =
                             ( sDomN.aspectionMenuMembersCount || 0 ) + 1;
@@ -491,10 +491,10 @@
                 //------------------------------------------------------------
                 //     for example for claim/english header with default === "1"
                 //         sconf.asp8theor_menus[ 'aspect' ].default='english';
-                //         sconf.asp8theor_menus[ 'theorion' ].default='claim';
+                //         sconf.asp8theor_menus[ 'textSection' ].default='claim';
                 if( has( sapp, 'amodel_initial' ) ) {
                     var ww = sapp.amodel_initial;
-                    if( ww.theorion === leafId || ww.aspect === leafId ) {
+                    if( ww.textSection === leafId || ww.aspect === leafId ) {
                         men[ "default" ] = leafId;
                     }
                 }
@@ -508,8 +508,8 @@
                     men.duplicates[ leafId ].caption = essayHeader.menuCaption;
                     men.duplicates[ leafId ].studylab = essayHeader.studylab;
                 }
-                if( essayHeader.theorionCaption && mcat_id === 'theorion' ) {
-                    men.duplicates[ leafId ].caption = essayHeader.theorionCaption;
+                if( essayHeader.textSectionCaption && mcat_id === 'textSection' ) {
+                    men.duplicates[ leafId ].caption = essayHeader.textSectionCaption;
                 }
             }
             //=======================================

--- a/src/base/parser/LANDING-VI-exegs2frags.js
+++ b/src/base/parser/LANDING-VI-exegs2frags.js
@@ -54,11 +54,11 @@
         //==============================================
         // //\\ sapwns script-embedded-in-text to html
         //==============================================
-        eachprop( exegs, ( theorionAspects, theorion_id ) => {
-            eachprop( theorionAspects, ( exAspect, aspect_id ) => {
+        eachprop( exegs, ( textSectionAspects, textSection_id ) => {
+            eachprop( textSectionAspects, ( exAspect, aspect_id ) => {
                 exAspect.subexegs.forEach( ( subexeg, exegId ) => {
                     //dirt: subexeg.domComponents  = [];
-                    subexeg.classStr       = 'original-text ' + theorion_id + ' ' + aspect_id +
+                    subexeg.classStr       = 'original-text ' + textSection_id + ' ' + aspect_id +
                                              ' subessay-' + subexeg.essayHeader.subessay;
                     //-----------------------------------------------------
                     // //\\ preliminary prepasing to extract active content

--- a/src/plugins/topic-scenario/executes-topic-scenario.js
+++ b/src/plugins/topic-scenario/executes-topic-scenario.js
@@ -78,11 +78,11 @@
             return;
         }
 
-        var { theorion, aspect, subessay } = amode;
+        var { textSection, aspect, subessay } = amode;
         if( runOnSubessay ) {
             subessay = runOnSubessay;
         }
-        var subessayRack    = exegs[ theorion ][ aspect ].subessay2subexeg[ subessay ];
+        var subessayRack    = exegs[ textSection ][ aspect ].subessay2subexeg[ subessay ];
         var stateId2state   = subessayRack.stateId2state;
         var scenarioState   = haz( stateId2state, subessayRack.scenario_stateId );
         if( !scenarioState ) {
@@ -255,13 +255,13 @@
     function restylifyUserConsole({
         subessay,
         style,
-        theorion,   //optional, if missed taken from state
+        textSection,   //optional, if missed taken from state
         aspect,     //optional, if missed taken from state
     }){
-        theorion = theorion || amode.theorion;
+        textSection = textSection || amode.textSection;
         aspect = aspect || amode.aspect;
         cssPath = '.original-text' +
-                  '.' + theorion +
+                  '.' + textSection +
                   '.' + aspect +
                   '.subessay-' + subessay +
                   ' .model-user-feedback';

--- a/src/plugins/topic-scenario/parses-topic-scenario.js
+++ b/src/plugins/topic-scenario/parses-topic-scenario.js
@@ -46,9 +46,9 @@
         var PURGE_EVENT = /^>\s/;
 
         //                 "exersise"
-        eachprop( exegs, ( theorionAspects, theorion_id ) => {
+        eachprop( exegs, ( textSectionAspects, textSection_id ) => {
         //                               "subtopics"
-            eachprop( theorionAspects, ( exAspect, aspect_id ) => {
+            eachprop( textSectionAspects, ( exAspect, aspect_id ) => {
                 exAspect.subexegs.forEach( ( subexeg, exegId ) => {
 
                     var scenarioScript = haz( subexeg, 'scenarioScript' );


### PR DESCRIPTION
"theorion" referred to text sections such as claim, proof, corollary, scholium, theorem, solution (and their plurals). There were variations on this term, such as "theorionId" and "theorionCaption". These have all renamed to "textSection" (or "textSectionId", "textSectionCaption", etc).