### PR TITLE
P1 fix bugs when the time slider nears max

### DIFF
--- a/contents/b1sec2prop1/js/does-mask-all-svg.js
+++ b/contents/b1sec2prop1/js/does-mask-all-svg.js
@@ -41,6 +41,16 @@
                 });
             });
         });
+
+        //Hide all purple triangles.
+        //As the delta time slider is moved to left more purple triangles are added to the model area.  However when its moved back
+        //to the right they are never removed.  Therefore it's important to hide all of them here (then only show the correct ones in 
+        //"unmasks-visible-path-svg.js").
+        rg?.pathRacks?.pathRacks?.forEach( (prack, index) => {
+            const paintee = rg[ 'kepltr-' + (index) ];
+            if (paintee)
+                $$.$(paintee.svgel).addClass( 'undisplay' );
+        });
     }
 
 

--- a/contents/b1sec2prop1/js/model-groupify-steps.js
+++ b/contents/b1sec2prop1/js/model-groupify-steps.js
@@ -112,7 +112,11 @@
                 fgroup.push( rg[ fappliedKey ] );   
                 fgroup.push( rg[ tipKey ] );   
 
-                if( pix<pathRacks.length-1 ) {
+                //The following previously checked "pix<pathRacks.length-1", however pathRacks.length varies even when the desired result doesn't.
+                //As the delta time slider is moved to the left pathRacks.length increases, however when moved back to the right pathRacks.length 
+                //doesn't decrease.  This means that the following would sometimes get added for an extra step.  rg.spatialSteps-1 always has the
+                //correct value, and therefore a consistent result.
+                if (pix < rg.spatialSteps - 1) {
                   fgroup.push( rg[ 'kepltr-' + pix ] );
                   fgroup.push( rg[ 'pathSegment-' + (pix) ] );
                 }

--- a/contents/b1sec2prop1/js/model8media-lib.js
+++ b/contents/b1sec2prop1/js/model8media-lib.js
@@ -42,7 +42,10 @@
     {
         var st      = rg.stepIx.value;
         var path    = rg.path.pos;
-        if( st >= path.length -1 ) return; //no second point
+        //Constrain the step value as follows.  Previously "if( st >= path.length -1 ) return;" was run however this caused an issue.
+        //The positions for the “perpendicular” and “rectilinear tangent” lines in P1 “Corollary 1”, didn't get updated when the time 
+        //slider was at its maximum and the delta time slider was dragged to the left.
+        st = Math.min(st, path.length -1);
 
         //perpendicular to unseen lines looks awkward
         //st -= rg.substepIx < 2 ? 1 : 0;
@@ -61,8 +64,8 @@
                 y       : rgP.medpos[1]-10,
             });
         });
-        ssF.pnames2line( 'S', 'P', );
-        ssF.pnames2line( 'T', 'P', );
+        ssF.pnames2line( 'S', 'P', );  // SP
+        ssF.pnames2line( 'T', 'P', );  // TP
         //rg.P.p is unit vector interface
         rg.P.p = mat.p1_to_p2( rg.S.pos, rg.P.pos );
 

--- a/contents/b1sec2prop1/js/time-slider.js
+++ b/contents/b1sec2prop1/js/time-slider.js
@@ -300,7 +300,11 @@
         rg.substepIx    = stepIx4%4;
         //steps in its original meaning
         var stepIx      = ( stepIx4 - rg.substepIx ) / 4;
-        stepIx          = Math.min( stepIx, rg.spatialSteps - 1 );
+        //The following line caused some bugs, has been commented out, and left for reference.  If the delta time slider is moved to the
+        //left of its maximum eg. 0.73, then when the time slider is moved to the left from its maximum, the time shown first increases
+        //then decreases (eg. 9.43 to 10.15 then back to 9.43).  This caused similar increasing/decreasing issues for the “path step” text
+        //in the Proof tab, and showing/hiding the last red force vector in the model area.
+        // stepIx          = Math.min( stepIx, rg.spatialSteps - 1 );
         toreg( 'stepIx' )( 'value', stepIx );
         /*
             c cc( 'ctime=' + ctime +

--- a/contents/b1sec2prop1/js/unmasks-visible-path-svg.js
+++ b/contents/b1sec2prop1/js/unmasks-visible-path-svg.js
@@ -73,83 +73,40 @@
         // always shows first Kepler's triangle to show
         // all other Kepler's triangles are equal to it
         $$.$( rg[ 'kepltr-' + 0 ].svgel).removeClass( 'undisplay' );
+        //Also show the path segment.
+        $$.$( rg[ 'pathSegment-' + 0 ].svgel).removeClass( 'undisplay' );
         //--------------------------------------
         // \\// picture drawing began
         //--------------------------------------
 
 
-
         //----------------------------------------------
-        // //\\ makes visible previous path
+        // //\\ Show the following group decorations (eg. purple triangles, forces etc.).
         //----------------------------------------------
-        let pathRacksLen1 = pathRacks.length-1;
-        pathRacks.forEach( (prack, pix ) => {
+        //See "model-groupify-steps.js" function "trajectoryShapes_2_groups__III" where the groups are setup for more details.
 
-            //--------------------------------------------
-            // //\\ makes visible already accomplished path
-            //      by direct svg-undisplay
-            //--------------------------------------------
-            //not used:
-            //$$.$(prack.svgel).removeClass( 'undisplay' );
+        //Each step has decorations that should be shown.  Each step corresponds to a group, and each group has sub-groups which 
+        //correspond to substeps.  Therefore any group before the current step ("stepIx") should show its final sub-group, the 
+        //current step should show its sub-group corresponding to the current substep ("substepIx"), and any remaining groups
+        //shouldn't be shown.
 
-            if( pix > 0 && pix <= stepIx && pix < pathRacksLen1 ) {
-                $$.$( rg[ 'pathSegment-' + (pix-1) ].svgel)
-                    .removeClass( 'undisplay' );
-
-                //makes visible all kepler triangles along the path,
-                //they will be in zebra-colors in proof to distinguish,
-                //if( stepIx < 6 || pix < stepIx-1 ) {
-                    $$.$( rg[ 'kepltr-' + (pix-1) ].svgel)
-                        .removeClass( 'undisplay' );
-                //}
+        //Don't go beyond the current step, the number of triangles that should be shown, or the length of the array.
+        const indexMax = Math.min(stepIx, rg.spatialSteps - 1, pathIx_2_pathSubsteps.length - 1);
+        //Start with the second group (see the "picture drawing began" section above for the first one).
+        for (let index = 1; index <= indexMax; index++) {
+            const fgroups = pathIx_2_pathSubsteps[index];
+            const indexFGroupsMax = fgroups.length-1;
+            
+            const indexSubstep = Math.min((index < stepIx ? indexFGroupsMax : substepIx), indexFGroupsMax);
+            if (indexSubstep > -1) {
+                fgroups[indexSubstep].forEach( (paintee) => {
+                    $$.$(paintee.svgel).removeClass( 'undisplay' );
+                    paintee?.vectorArrowSvg$?.removeClass( 'undisplay' );
+                });
             }
-            //--------------------------------------------
-            // //\\ makes visible  previous forces
-            //      'force-N' and
-            //      'force-N-1' shapes
-            //      by direct svg-undisplay
-            //--------------------------------------------
-            if( pix < stepIx - 1) {
-                var fkey        = 'force-' + pix;
-                var fappliedKey = fkey + '-applied';
-                var tipKey      = fkey+'-1';
-                let rgX         = rg[ fappliedKey ];
-                $$.$(rgX.svgel).removeClass( 'undisplay' );
-                rgX.vectorArrowSvg$.removeClass( 'undisplay' );
-                $$.$(rg[ tipKey ].svgel).removeClass( 'undisplay' );
-            }
-            //--------------------------------------------
-            // \\// makes visible  previous forces
-            // \\// makes visible already accomplished path
-            //--------------------------------------------
-        });
-        //----------------------------------------------
-        // \\// makes visible previous path
-        //----------------------------------------------
-
-
-
-        //----------------------------------------------
-        // //\\ makes visible last fragment's fgroup,
-        //      last steps where already displayed,
-        //      by direct svg-undisplay,
-        //      there can be less fgroups than 4
-        //----------------------------------------------
-        //.sets phase to latest fgroups index === substepIx
-        var fgroups           = pathIx_2_pathSubsteps[ stepIx ];
-        var fgroups_substepIx = Math.min( fgroups.length-1, substepIx );
-        var fgroup            = fgroups[ fgroups_substepIx ];
-        //if( !fgroup ) return;
-        ///this visualizes necessary fragments:
-        if( amode.aspect !== 'claim' ) {
-            fgroup.forEach( (paintee, leafix) => {
-                $$.$(paintee.svgel).removeClass( 'undisplay' );
-                let vectorArrowSvg$ = haz( paintee, 'vectorArrowSvg$' );
-                vectorArrowSvg$ && vectorArrowSvg$.removeClass( 'undisplay' );
-            });
         }
         //----------------------------------------------
-        // \\// makes visible last fragment,
+        // \\// Show the following group decorations (eg. purple triangles, forces etc.).
         //----------------------------------------------
 
 


### PR DESCRIPTION
Fixes many bugs that occurred when the time slider nears max.  Also made improvements to the code and comments.
-A final triangle was added then removed and sometimes drawn in the wrong place
-Time slider increasing/decreasing issues
-Ensure lines in P1 “Corollary 1” always get updated
-Ensure triangles and path segments are added for the correct steps