### PR TITLE
Alternate shades of purple triangles for theorem tab

### DIFF
--- a/contents/b1sec2prop1/js/global-css-overrider.js
+++ b/contents/b1sec2prop1/js/global-css-overrider.js
@@ -65,14 +65,6 @@
                 opacity : 0.7;
             }
             `,
-
-            //The following overrides the above odd and even triangle colors for the Theorem tab in P1 and P2.
-            // div.bsl-approot.textSection--claim svg .tp-kepler-triangle.triangle-odd,
-            // div.bsl-approot.textSection--claim svg .tp-kepler-triangle.triangle-even {
-            //     fill : #8888ff;
-            //     opacity : 0.7;
-            //}
-            //`,
             'global-css-overrider'
         );
     }

--- a/contents/b1sec2prop1/js/global-css-overrider.js
+++ b/contents/b1sec2prop1/js/global-css-overrider.js
@@ -64,13 +64,15 @@
                 fill : #9999ff;
                 opacity : 0.7;
             }
-
-            div.bsl-approot.textSection--claim svg .tp-kepler-triangle.triangle-odd,
-            div.bsl-approot.textSection--claim svg .tp-kepler-triangle.triangle-even {
-                fill : #8888ff;
-                opacity : 0.7;
-            }
             `,
+
+            //The following overrides the above odd and even triangle colors for the Theorem tab in P1 and P2.
+            // div.bsl-approot.textSection--claim svg .tp-kepler-triangle.triangle-odd,
+            // div.bsl-approot.textSection--claim svg .tp-kepler-triangle.triangle-even {
+            //     fill : #8888ff;
+            //     opacity : 0.7;
+            //}
+            //`,
             'global-css-overrider'
         );
     }


### PR DESCRIPTION
Update: The code and comment have been removed.
The default odd and even purple triangle colors were overridden for the Theorem tab in P1 and P2, and replaced with a different single color.  This disables the override so that they alternate.