### PR TITLE
L9 claim tab only show green, unlabeled point controlling Ag to g

### DIFF
--- a/contents/b1sec1lemma10/js/amode8captures.js
+++ b/contents/b1sec1lemma10/js/amode8captures.js
@@ -1,6 +1,6 @@
 ( function() {
     var {
-        ns, sn, paste, capture, amode, rg, sDomF, ssD, ssF, fconf,
+        ns, sn, paste, capture, amode, rg, sDomF, ssD, ssF, fconf, sconf,
     } = window.b$l.apptree({
         ssFExportList :
         {
@@ -61,7 +61,8 @@
         if(
             logic_phase === 'proof'
         ) {
-            rg.tiltRatio = { value : 1.3 };
+            //Set and constrain the tiltAngle as follows.
+            rg.tiltAngle.value = Math.min(Math.max(-10, sconf.tiltAngle_min), sconf.tiltAngle_max);
             [
                 'Ae',
                 'e',

--- a/contents/b1sec1lemma9/js/amode8captures.js
+++ b/contents/b1sec1lemma9/js/amode8captures.js
@@ -30,19 +30,37 @@
             logic_phase === 'claim'
         ) {
             [
+                //points
                 'b',
                 'c',
                 'd',
                 'e',
                 'f',
                 'g',
+                'pivotPoint1',
+                
+                //lines
                 'Ae',
                 'Ab',
                 'Ac',
                 'Ad',
+                'Ag',
                 'db',
                 'ec',
+
+                //curves
+                "Abc",
                 'remoteCurve',
+
+                //areas
+                "Abd",
+                "Ace",
+                "area-Abd",
+                "area-Ace",
+
+                //linear areas
+                "Afd",
+                "Age",
             ].forEach( gname => { rg[ gname ].undisplay = true; });
         }
         return captured;

--- a/contents/b1sec1lemma9/js/init-model-parameters.js
+++ b/contents/b1sec1lemma9/js/init-model-parameters.js
@@ -24,7 +24,7 @@
         ssD.curvePivots   = sconf.curvePivots.concat([]);
         ssD.tC            = sconf.tC;
         ssD.claimRatio    = sconf.claimRatio;
-        toreg( 'tiltRatio' )( 'value', sconf.tiltRatio );
+        toreg( 'tiltAngle' )( 'value', sconf.tiltAngle );
     }
 }) ();
 

--- a/contents/b1sec1lemma9/js/media-upcreate.js
+++ b/contents/b1sec1lemma9/js/media-upcreate.js
@@ -87,7 +87,7 @@
         //==========================================
 
 
-        // //\\ paints curve with two pivot points
+        // //\\ paints curve with pivot points
         var mainCurve = toreg( 'mainCurve' )();
         mainCurve.mediael = bezier.mediafy({
             mediael : mainCurve.mediael, //this is a rack, not svg: goal?: not to recreate DOM.
@@ -97,8 +97,10 @@
             {
                 'stroke-width' : 1 * sconf.thickness
             },
+            //Ensure second paint pivot is hidden.  Otherwise a small dot will be in its location for the claim tab, since the point that would 
+            //cover it for other tabs is hidden.
             paintPivots : {
-                topaint : [ null, true, true ],
+                topaint : [ null, null, true ],
                 attrs :
                 {
                     'stroke-width' : 1 * sconf.thickness,

--- a/contents/b1sec1lemma9/js/sconf.js
+++ b/contents/b1sec1lemma9/js/sconf.js
@@ -205,7 +205,7 @@
             },
 
             'pivotPoint1' : { 
-                pcolor      : result,
+                pcolor      : proof,
                 doPaintPname : false,
                 letterAngle : 90,
             },
@@ -258,16 +258,10 @@
             curvePivots :
             [
                 [0, 0],
-                //[326.8, 715.3],
-                //[326.8*1.05, 742*1.05],
-
-                [270.19, 612.8],
-
-                //[72.29, 621.2],
-
-                //[1516.1, 569.9]
-                //[1516.1, 495] //tmp
+                //The bezier middle pivot is constrained in "model-upcreate.js" beginning of "model_upcreate" function.
+                [440, APP_MODEL_Y_RANGE],
                 [ 1060, 567 ]
+
                 /* very good for debug: simple curve
                 [0, 0],
                 [500, 1000],
@@ -281,28 +275,27 @@
             //*************************************************
             APP_MODEL_Y_RANGE,
             //:ranges
-            tanA_min : 0.1, //pivot1x/pivot1y minimum
-            pivot1y_max : APP_MODEL_Y_RANGE * 0.99,
+            angleA_min : 5.71,  //Degrees
+            pivot1y_max : APP_MODEL_Y_RANGE * 0.99,  //Left here for lemma 10
             pivot2x_max : APP_MODEL_Y_RANGE * 1.8,
             pivot2y_min : APP_MODEL_Y_RANGE * 0.3,
             pivot2y_max : APP_MODEL_Y_RANGE * 0.99,
 
 
             //bezier parameter t of point C on principal curve
-            //tC : 0.5, //good for debug
-            tC : 0.50077 / 0.79 ,
+            tC : 0.48,  //This value ensures line EC not too high and upper bezier curve not cutoff.
 
             claimRatio : 0.74081,
             //range:
             claimRatio_max : 0.9, //Dy_per_Ey
 
 
-            tiltRatio : 1,   //controls DB-line tilt: 
-                             //1 is perpendicular; < 1 dy/dx is negative, > 1 is positive
+            tiltAngle : 0.0, //controls EC-line tilt:
+                             //in degrees;  0.0 is horizontal;  from perspective of point E (+ve when C y above E y);
             //:ranges
-            tiltRatio_min   : 0.4,
-            tiltRatio_max   : 1.5,
-            Ep2yrange_max   : 0.8,
+            tiltAngle_min   : -15,
+            tiltAngle_max   : 40,
+
             Cx_min          : 0.1,
             //*************************************************
             // \\// lemma model parameters

--- a/src/vendor/bsl/mat/mat.js
+++ b/src/vendor/bsl/mat/mat.js
@@ -13,6 +13,8 @@
         }
         mat.powersOf2 = powersOf2;
         mat.atan2PI = atan2PI;
+        mat.degToRad = degToRad;
+        mat.radToDeg = radToDeg;
     })();
 
     
@@ -92,7 +94,17 @@
         let angle = Math.atan2( vector[1], vector[0] );
         return angle < 0 ?  2 * Math.PI + angle : angle;
     }
-    
+
+
+    //converts angle from degrees to radians
+    function degToRad(angle){
+        return angle / 180 * Math.PI;
+    }
+
+    //converts angle from radians to degrees
+    function radToDeg(angle){
+        return angle * 180 / Math.PI;
+    }
 }) ();
 
 


### PR DESCRIPTION
-Claim tab now only shows the green part of the diagram, with the Proof tab adding the blue
-The unlabeled point handle controlling line Ag is constrained to be on line ec at point g
-Added functions to convert angles from degrees to radians and radians to degrees
-Switched tiltRatio to tiltAngle (including Lemma 10 see its “amode8captures.js”).  Note from message before change occurred describing why it's needed below...

"When line ec was horizontal the control point was easy to move. However once point ‘E’ was moved vertically and the line became angled an issue occurred. Once the control point moved the diagram would get recalculated, and the angle of line ec would change. This meant that the control point was no longer on line ec, but offset from it. It turns out that the angle change occurred because point ‘E’ is calculated relative to point ‘C’ using a ratio called ‘tiltRatio’. Initially it has a value of 1 meaning that both those points end up having the same y value, and therefore line ec is horizontal. However once point ‘E’ is moved their y values become different, and therefore line ec is no longer horizontal. If point ‘C’ moves (for example the control point is moved) then the angle changes. Given that as the angle changes it remains similar, I decided the best solution was to store and use an angle to calculate point ‘E’ relative to point ‘C’ instead. This means that the diagram should behave in almost the exact same way, but the control point now stays on line ec."