### PR TITLE
Make label/point F as solid as other labels/points

### DIFF
--- a/contents/lemma2/js/sconf.js
+++ b/contents/lemma2/js/sconf.js
@@ -243,7 +243,7 @@
             },
 
             F : {
-                pcolor      : predT[ "widest-rectangular" ],
+                pcolor      : predT.given,
                 letterAngle : 45,
                 initialR    : 1.6,
             },


### PR DESCRIPTION
-Both the label and point for F included transparency, which is why they appeared less solid.  They were a different color than the other labels/points (which are opaque), therefore F has been switched to use the same color.
-Note that the old color "widest-rectangular" is still in use, for example by the L3 Proof tab when “parallelogram FAaf” is highlighted.