### PR TITLE
L10 remove unneeded lines/points, tighten up data

### DIFF
--- a/contents/b1sec1lemma10/js/amode8captures.js
+++ b/contents/b1sec1lemma10/js/amode8captures.js
@@ -1,20 +1,10 @@
 ( function() {
-    var {
-        ns, sn, paste, capture, amode, rg, sDomF, ssD, ssF, fconf, sconf,
-    } = window.b$l.apptree({
-        ssFExportList :
-        {
-            amode2rgstate,
-        },
-    });
+    var { ns, sn, paste, capture, amode, rg, sDomF, ssD, ssF, fconf, sconf, } 
+        = window.b$l.apptree({ ssFExportList : { amode2rgstate, }, });
     setCapture();
     return;
 
-
-
-
-
-
+    
     function setCapture()
     {
         paste( capture,
@@ -33,16 +23,21 @@
             'c',
             'd',
             'e',
+            'F', 
+            'G',
             'f',
             'g',
+            'pivotPoint1',
             'Ae',
             'Ab',
             'Ac',
             'Ad',
+            'Ag',
             'db',
             'ec',
             //'df',
             //'eg',
+            'AG',
             'remoteCurve',
 
             "Abd",
@@ -58,16 +53,7 @@
         rg.pivotPoint1.pcolor = sDomF.getFixedColor( 'given' )
         rg.Ag.pcolor = sDomF.getFixedColor( 'given' )
 
-        if(
-            logic_phase === 'proof'
-        ) {
-            //Sets and constrains the tiltAngle as follows.
-            //rg.tiltAngle.value = Math.min(Math.max(-10, sconf.tiltAngle_min), sconf.tiltAngle_max);
-            [
-                'Ae',
-                'e',
-            ].forEach( gname => { rg[ gname ].undisplay = false; });
-        } else if( logic_phase === 'claim' ) {
+        if( logic_phase === 'claim' ) {
             //Sets and constrains the tiltAngle as follows.
             rg.tiltAngle.value = 0;
         }

--- a/contents/b1sec1lemma9/js/d8d-model.js
+++ b/contents/b1sec1lemma9/js/d8d-model.js
@@ -1,33 +1,7 @@
 ( function() {
-    var {
-        ns, 
-        sn,
-        bezier,
-        fapp,
-        fconf,
-        sconf,
-        sDomF,
-        sDomN,
-        amode,
-        ssD,
-        ssF,
-        rg,
-        stdMod,
-    } = window.b$l.apptree({
-        stdModExportList :
-        {
-            initDragModel,
-        },
-    });
+    var { ns, sn, bezier, fapp, fconf, sconf, sDomF, sDomN, amode, ssD, ssF, rg, stdMod, } 
+        = window.b$l.apptree({ stdModExportList : { initDragModel, }, });
     return;
-
-
-
-
-
-
-
-
 
 
     //==========================================
@@ -197,47 +171,50 @@
         //-point g
         //  -Note that lemma 10 shares code with lemma 9
         //  -Would work well for lemma 9 as the bezier middle pivot and point g are supposed to be the same point
-        //  -Wouldn't work well for lemma 10 as it uses a separate point (pivotPoint1) that's not supposed to be the same as point g
+        //  -Didn't work well for lemma 10, previously it had a separate point (pivotPoint1) that's not supposed to be the same as point g
         //-pivotPoint1
-        //  -Works for both lemma 9 and 10
+        //  -Works for lemma 9 (and 10 when it had this separate point)
 
-        var wpoint              = rg.pivotPoint1;
-        wpoint.dragDecorColor   = ns.haz( rg.pivotPoint1, 'pcolor' ) || sDomF.getFixedColor( 'proof' );
-        wpoint.spinnerClsId     = 'pivotPoint1';
-        createDragger({
-            achieved            : ssD.curvePivots[1].concat([]),
-            pointWrap           : wpoint,
-            cssClasses          : ['axis-x'],
-            doProcess : function( arg )
-            {
-                var ach = arg.pointWrap.achieved;
-                var pv = ssD.curvePivots[1];
-                switch( arg.down_move_up ) {
-                    case 'down':
-                        //Update ach.achieved to prevent 'jumping' in case the bezier middle pivot moved (eg. point E was moved and constrained it).
-                        ach.achieved = pv.concat([]);
-                    break;
-                    case 'up':   ach.achieved = pv.concat([]);
-                                 sDomF.detected_user_interaction_effect();
-                    break;
-                    case 'move': 
-                        //Dragger offset in x direction relative to initial dragger position (note dragger offset and diagram use different scales).
-                        const wwMed = sDomF.out2inn();
-                        const xOffset = wwMed * sconf.inn2mod_scale * arg.surfMove[0];
+        //Ensure only draggable for lemma 9, as lemma 10 no longer has this point.
+        if (fconf.sappId === "b1sec1lemma9") {
+            var wpoint              = rg.pivotPoint1;
+            wpoint.dragDecorColor   = ns.haz( rg.pivotPoint1, 'pcolor' ) || sDomF.getFixedColor( 'proof' );
+            wpoint.spinnerClsId     = 'pivotPoint1';
+            createDragger({
+                achieved            : ssD.curvePivots[1].concat([]),
+                pointWrap           : wpoint,
+                cssClasses          : ['axis-x'],
+                doProcess : function( arg )
+                {
+                    var ach = arg.pointWrap.achieved;
+                    var pv = ssD.curvePivots[1];
+                    switch( arg.down_move_up ) {
+                        case 'down':
+                            //Update ach.achieved to prevent 'jumping' in case the bezier middle pivot moved (eg. point E was moved and constrained it).
+                            ach.achieved = pv.concat([]);
+                        break;
+                        case 'up':   ach.achieved = pv.concat([]);
+                                    sDomF.detected_user_interaction_effect();
+                        break;
+                        case 'move': 
+                            //Dragger offset in x direction relative to initial dragger position (note dragger offset and diagram use different scales).
+                            const wwMed = sDomF.out2inn();
+                            const xOffset = wwMed * sconf.inn2mod_scale * arg.surfMove[0];
 
-                        //Calculate the new bezier middle pivot, ensure it's on line ec.
-                        //Would be (newX, yRange) if line ec was horizontal.  Then tiltAngle adds or subtracts in the y direction.
-                        const newX = ach.achieved[0] + xOffset;  //New x pos for point being dragged.
-                        modCurvPivots[1][0] = newX;
-                        modCurvPivots[1][1] = yRange + Math.tan(mat.degToRad(rg.tiltAngle.value)) * modCurvPivots[1][0];
-                        
-                        //Note the bezier middle pivot is further constrained in "model-upcreate.js" beginning of "model_upcreate" function.
+                            //Calculate the new bezier middle pivot, ensure it's on line ec.
+                            //Would be (newX, yRange) if line ec was horizontal.  Then tiltAngle adds or subtracts in the y direction.
+                            const newX = ach.achieved[0] + xOffset;  //New x pos for point being dragged.
+                            modCurvPivots[1][0] = newX;
+                            modCurvPivots[1][1] = yRange + Math.tan(mat.degToRad(rg.tiltAngle.value)) * modCurvPivots[1][0];
+                            
+                            //Note the bezier middle pivot is further constrained in "model-upcreate.js" beginning of "model_upcreate" function.
 
-                        stdMod.model8media_upcreate();
-                    break;
+                            stdMod.model8media_upcreate();
+                        break;
+                    }
                 }
-            }
-        });
+            });
+        }
         //.........................................
         // \\// moves bezier middle pivot
         //.........................................

--- a/contents/b1sec1lemma9/js/main-legend.js
+++ b/contents/b1sec1lemma9/js/main-legend.js
@@ -1,33 +1,12 @@
 ( function() {
-    var {
-        $$,
-        sconf, sDomF, sDomN, ssD, ssF,
-        stdMod, rg, toreg,
-    } = window.b$l.apptree({
-        ssFExportList :
-        {
-            upcreate_mainLegend,
-            create_digital_legend,
-        },
-    });
+    var { $$, sconf, fconf, sDomF, sDomN, ssD, ssF, stdMod, rg, toreg, } 
+        = window.b$l.apptree({ ssFExportList : { upcreate_mainLegend, create_digital_legend, }, });
     var clustersToUpdate = [];
     var clustersToUpdate_claim = [];
     var AbdAce_row$;
     return;
 
-
-
-
-
-
-
-
-
-
-
-
-
-
+    
     function create_digital_legend()
     {
         var mlegend = toreg( 'main-legend' )();
@@ -211,12 +190,14 @@
         //=======================
         // //\\ model linear unit 
         //=======================
-        var row = $$.c('tr')
-            //.addClass('tostroke')
-            .to(tb)();
-        //$$.c('td').a('colspan','6').to(row);
-        makeCl( row, 'model-linear-unit', 'Ae').cls('tp-_ae-length tostroke');
-        clustersToUpdate['model-linear-unit'].innerHTML = sconf.LEGEND_NUMERICAL_SCALE.toFixed();
+        if (fconf.sappId === "b1sec1lemma9") {
+            var row = $$.c('tr')
+                //.addClass('tostroke')
+                .to(tb)();
+            //$$.c('td').a('colspan','6').to(row);
+            makeCl( row, 'model-linear-unit', 'Ae').cls('tp-_ae-length tostroke');
+            clustersToUpdate['model-linear-unit'].innerHTML = sconf.LEGEND_NUMERICAL_SCALE.toFixed();
+        }
         //=======================
         // \\// model linear unit 
         //=======================

--- a/contents/b1sec1lemma9/js/sconf.js
+++ b/contents/b1sec1lemma9/js/sconf.js
@@ -266,7 +266,6 @@
             APP_MODEL_Y_RANGE,
             //:ranges
             angleA_min : 5.71,  //Degrees
-            pivot1y_max : APP_MODEL_Y_RANGE * 0.99,  //Left here for lemma 10
             pivot2x_max : APP_MODEL_Y_RANGE * 1.8,
             pivot2y_min : APP_MODEL_Y_RANGE * 0.3,
             pivot2y_max : APP_MODEL_Y_RANGE * 0.99,


### PR DESCRIPTION
All tabs:
-remove line AG, including the extension to the unnamed point past G
-remove points F, G, and unnamed point past G

Proof tab:
-remove line Ee
-remove point e
-Remove data line “Ae = 100” for L10

-Removed padding left to "tighten up" the data (remove excess white space around the equals signs) for L10.  However note that padding for the other models legend data is also modified with this change.
-Disable dragging of bezier middle pivot for L10 to ensure it can’t be dragged by accident, as that point has been hidden.
-Removed unused constant pivot1y_max which was previously used by L10 to constrain the position of pivotPoint1.