### PR TITLE
Qpos

### DIFF
--- a/changelog/changelog.md
+++ b/changelog/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2026-4-? ( Version, 0.9)
+### Improved
+* Proposition 9
+	* angles remain constant as P is moved in accordance with the first solution
+
 ## 2026-3-25 (Magenta Version, 0.8)
 ### Improved
 * General

--- a/contents/b1sec2prop6/js/completes-sliders-creation.js
+++ b/contents/b1sec2prop6/js/completes-sliders-creation.js
@@ -10,7 +10,7 @@
     function creates_S_slider() {
         rg.S.acceptPos = newPos => {
             //does this for decorational purposes
-            stdMod.rebuilds_orbit( ssD.Dt );
+            stdMod.rebuilds_orbit();
             //this permits an orbitrary move
 
             updatePointPPos();
@@ -71,7 +71,7 @@
                 pos[1] += dpos1*c2p;
                 bezio.updatesPivot( pos, cpix );
 
-                stdMod.rebuilds_orbit( ssD.Dt );
+                stdMod.rebuilds_orbit();
                 updatePointPPos();
 
                 ///updates curve pivots every time:

--- a/contents/b1sec2prop7/js/amode8captures.js
+++ b/contents/b1sec2prop7/js/amode8captures.js
@@ -79,7 +79,7 @@
         modifyDecorationVisibility();
 
         ssD.stashedVisibility = null;
-        stdMod.rebuilds_orbit(ssD.Dt);
+        stdMod.rebuilds_orbit();
         sDomF.detected_user_interaction_effect( 'doShowDiagram' );
         return captured;
     }

--- a/contents/b1sec2prop7/js/completes-sliders-creation.js
+++ b/contents/b1sec2prop7/js/completes-sliders-creation.js
@@ -11,7 +11,7 @@
         rg.S.dragPriority  = 30;
         rg.S.acceptPos = newPos => {
             //does this for decorational purposes
-            stdMod.rebuilds_orbit( ssD.Dt );
+            stdMod.rebuilds_orbit();
             //this permits an orbitrary move
             return true;
         }

--- a/contents/b1sec2prop9/js/model-upcreate.js
+++ b/contents/b1sec2prop9/js/model-upcreate.js
@@ -20,11 +20,51 @@
         rg.P.pos[1] = Porb.rr[1];
         var rr0 = rg.P.pos;
         var rrc = rg.S.pos;
-        var Qpos = q2xy( Porb.plusQ );
-        var rr = Qpos;
+        
+        // Determine Q position: use stored angle if available, else use computed plusQ
+        var Qpos;
+        if( ssD.anglePSQ !== undefined ){
+            // Find orbit point that maintains the stored angle from focus S
+            const angleSP = Math.atan2( rr0[1] - rrc[1], rr0[0] - rrc[0] );
+            const targetAngleSQ = angleSP + ssD.anglePSQ;
+            
+            // Search all orbit points for the one whose angle from S is closest to target
+            const qIndexToOrbit = ssD.qIndexToOrbit;
+            let bestQix = rg.P.qix;
+            let bestAngleDiff = Math.PI; // max possible angle difference
+            
+            for( let testQix = 0; testQix < qIndexToOrbit.length; testQix++ ){
+                if( testQix === rg.P.qix ) continue; // skip P itself
+                const testPoint = qIndexToOrbit[ testQix ].rr;
+                const testAngle = Math.atan2( testPoint[1] - rrc[1], testPoint[0] - rrc[0] );
+                let angleDiff = testAngle - targetAngleSQ;
+                
+                // Normalize angle difference to [-π, π]
+                while( angleDiff > Math.PI ) angleDiff -= 2 * Math.PI;
+                while( angleDiff < -Math.PI ) angleDiff += 2 * Math.PI;
+                
+                if( Math.abs(angleDiff) < Math.abs(bestAngleDiff) ){
+                    bestAngleDiff = angleDiff;
+                    bestQix = testQix;
+                }
+            }
+            Qpos = qIndexToOrbit[ bestQix ].rr;
+        } else {
+            // First time: compute Q from plusQ and initialize angle
+            Qpos = q2xy( Porb.plusQ );
+            const angleSP = Math.atan2( rr0[1] - rrc[1], rr0[0] - rrc[0] );
+            const angleSQ = Math.atan2( Qpos[1] - rrc[1], Qpos[0] - rrc[0] );
+            ssD.anglePSQ = angleSQ - angleSP;
+        }
+        
         rg.Q.pos[0] = Qpos[0];
         rg.Q.pos[1] = Qpos[1];
-        var side = [ Qpos[0] - rr0[0], Qpos[1] - rr0[1] ];
+
+        // for debugging
+        // const angleSP = Math.atan2( rr0[1] - rrc[1], rr0[0] - rrc[0] );
+        // const angleSQ = Math.atan2( Qpos[1] - rrc[1], Qpos[0] - rrc[0] );
+        // const anglePSQ = angleSQ - angleSP;
+        //console.log( 'Angle PSQ: ' + (anglePSQ * 180 / Math.PI).toFixed(2) + ' degrees' );
 
         // **api-input---plane-curve-derivatives
         var {

--- a/contents/b1sec3prop12/js/amode8captures.js
+++ b/contents/b1sec3prop12/js/amode8captures.js
@@ -30,7 +30,7 @@
         // \\// model
         //=============================================================
 
-        stdMod.rebuilds_orbit(ssD.Dt);
+        stdMod.rebuilds_orbit();
         //comment out to remove Book's diagram after timeout
         sDomF.detected_user_interaction_effect( 'doUndetected' );
         return captured;

--- a/src/base/lemma/study-model/kepler-orbit/creates-Q8P-sliders.js
+++ b/src/base/lemma/study-model/kepler-orbit/creates-Q8P-sliders.js
@@ -48,6 +48,14 @@
                 if( Dt < 0.05 ||
                     sconf.DT_SLIDER_MAX <= Dt ) return;
                 ssD.Dt = Dt;
+                
+                // Store PSQ to be used optionally in model-upcreate to maintain constant angle
+                const posPorb = qIndexToOrbit[ qix ].rr;
+                const posQorb = qIndexToOrbit[ Qqix ].rr;
+                const focusS = rg.S.pos;
+                const angleSP = Math.atan2( posPorb[1] - focusS[1], posPorb[0] - focusS[0] );
+                const angleSQ = Math.atan2( posQorb[1] - focusS[1], posQorb[0] - focusS[0] );
+                ssD.anglePSQ = angleSQ - angleSP;
             } else {
                 const q = qIndexToOrbit[ Qqix ].q;
                 let Dq = q - qIndexToOrbit[ qix ].q;

--- a/src/base/lemma/study-model/kepler-orbit/initiates_orbit8graph.js
+++ b/src/base/lemma/study-model/kepler-orbit/initiates_orbit8graph.js
@@ -55,7 +55,7 @@
 		}
     }
     
-    function rebuilds_orbit( keepThisDt ) {
+    function rebuilds_orbit() {
         const Q_STEPS = sconf.Q_STEPS;
 
         if (stdMod.recalculateOrbitStartAndEnd)
@@ -71,8 +71,10 @@
             const timeE = qIndexToOrbit[Q_STEPS].timeAtQ;
             ssD.timeRange = timeE - timeS;
         }
-        ssD.Dq = sconf.Dq0;
-        ssD.Dt = keepThisDt || sn( ssD, 'Dt', sconf.Dt0 );
+        const prevDq = ssD.Dq;
+        const prevDt = ssD.Dt;
+        ssD.Dq = prevDq !== undefined ? prevDq : sconf.Dq0;
+        ssD.Dt = prevDt || sn( ssD, 'Dt', sconf.Dt0 );
         stdMod.builds_force_plusQ_minusQ_and_related(sData.ULTIM_MAX);
         stdMod.builds_force_plusQ_minusQ_and_related(sData.ULTIM_ACTUAL);
         stdMod.builds_force_plusQ_minusQ_and_related();


### PR DESCRIPTION
- in Prop 9, angle PSQ is preserved while dragging P, rather than changing due to time
- rebuilds_orbit function no longer takes parameter, position of Q automatically maintained on tab switches and when moving other draggable points