### PR TITLE
fix so contents button doesn't show on homepage anymore

### DIFF
--- a/src/base/css/homepage.css
+++ b/src/base/css/homepage.css
@@ -28,6 +28,11 @@
     display : none;
 }
 
+/* use this to hide elements without affecting page layout */
+.non-visible {
+    opacity : 0;
+}
+
 .bsl-home-pane h1, .bsl-home-pane h2 {
     color: var(--color-white);
 }

--- a/src/base/dom/create/body.js
+++ b/src/base/dom/create/body.js
@@ -220,14 +220,14 @@
             fapp.fappRoot$.css( 'overflow', 'visible' );
             document.body.style.overflow = 'visible';
             $$.$( document.body ).addClass( 'contents' );
-
+            sDomN.homeButton$.addClass( 'non-visible' );
         } else {
             //(I) this erases css of front-page-pane
             ns.globalCss.clearStyleTag('home');
             
             fapp.homePage$.addClass( 'is-hidden' );
             sDomN.returnToLemmaButton$.addClass( 'non-displayed' );
-            sDomN.homeButton$.removeClass('non-displayed');
+            sDomN.homeButton$.removeClass('non-visible');
             
             document.body.style.overflow = 'hidden';
             $$.$(document.body).removeClass('contents');


### PR DESCRIPTION
- instead of using display:none to hide the Contents button, using opacity:0 instead so the header layout doesn't shift during the homepage overlay animation