### PR TITLE
Simplify logic

### DIFF
--- a/src/base/lemma/study-model/kepler-orbit/initiates_orbit8graph.js
+++ b/src/base/lemma/study-model/kepler-orbit/initiates_orbit8graph.js
@@ -29,7 +29,7 @@
         stdMod.creates_createOrUpdateOrbit();
         if (stdMod.calculateMaxGraphValues)
             stdMod.calculateMaxGraphValues();
-        stdMod.rebuilds_orbit(false, doGraph); // qIndexToOrbit populated here
+        stdMod.rebuilds_orbit(); // qIndexToOrbit populated here
 
         stdMod.creates__gets_orbit_closest_point();
 
@@ -62,7 +62,7 @@
 		}
     }
 
-    function rebuilds_orbit(setMaxGraphValues, doGraph = true) {
+    function rebuilds_orbit(setMaxGraphValues) {
         const Q_STEPS = sconf.Q_STEPS;
 
         if (stdMod.recalculateOrbitStartAndEnd)
@@ -87,10 +87,7 @@
         stdMod.builds_force_plusQ_minusQ_and_related(sData.ULTIM_MAX);
         stdMod.builds_force_plusQ_minusQ_and_related(sData.ULTIM_ACTUAL);
         stdMod.builds_force_plusQ_minusQ_and_related();
-		if (doGraph) {
-			stdMod.builds_orbit_data_graph(setMaxGraphValues);
-		}
-        // stdMod.builds_orbit_data_graph();
+		stdMod.builds_orbit_data_graph(setMaxGraphValues);
 
         //Adjust point P if out of bounds
         const qixMin = ssD.qix_graph_start;


### PR DESCRIPTION
Boolean parameter for whether to doGraph is not needed due to check inside rebuilds_orbit(). This was coded previously, but missed in a cherry pick.